### PR TITLE
feat(gb-9341): implement a simple mcp server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,9 @@ name = "anyhow"
 version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
+dependencies = [
+ "backtrace",
+]
 
 [[package]]
 name = "arc-swap"
@@ -826,7 +829,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1430,7 +1433,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "778e2ac28f6c47af28e4907f13ffd1e1ddbd400980a9abd7c8df189bf578a5ad"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2493,8 +2496,10 @@ dependencies = [
  "indoc",
  "insta",
  "reqwest",
+ "rmcp",
  "rustls",
  "serde",
+ "serde_json",
  "server",
  "tokio",
  "toml",
@@ -2547,7 +2552,7 @@ checksum = "e04d7f318608d35d4b61ddd75cbdaee86b023ebe2bd5a66ee0915f0bf93095a9"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2607,7 +2612,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2702,7 +2707,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2839,6 +2844,21 @@ name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
+
+[[package]]
+name = "mcp"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "axum",
+ "config",
+ "futures-util",
+ "http",
+ "rmcp",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "memchr"
@@ -3035,6 +3055,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "oauth2"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51e219e79014df21a225b1860a479e2dcd7cbd9130f4defd4bd0e191ea31d67d"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "getrandom 0.2.16",
+ "http",
+ "rand 0.8.5",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sha2 0.10.9",
+ "thiserror 1.0.69",
+ "url",
+]
+
+[[package]]
 name = "object"
 version = "0.36.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3164,6 +3204,12 @@ dependencies = [
  "smallvec",
  "windows-targets 0.52.6",
 ]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem-rfc7468"
@@ -3484,7 +3530,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.12.1",
+ "itertools 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.104",
@@ -3553,7 +3599,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3845,6 +3891,53 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37f2048a81a7ff7e8ef6bc5abced70c3d9114c8f03d85d7aaaafd9fd04f12e9e"
+dependencies = [
+ "axum",
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body",
+ "http-body-util",
+ "oauth2",
+ "paste",
+ "pin-project-lite",
+ "rand 0.9.1",
+ "reqwest",
+ "rmcp-macros",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tower-service",
+ "tracing",
+ "url",
+ "uuid",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72398e694b9f6dbb5de960cf158c8699e6a1854cb5bbaac7de0646b2005763c4"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.104",
+]
+
+[[package]]
 name = "rsa"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3916,7 +4009,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3929,7 +4022,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.9.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4023,6 +4116,19 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -4043,6 +4149,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -4139,6 +4257,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4270,6 +4399,7 @@ dependencies = [
  "config",
  "http",
  "log",
+ "mcp",
  "serde",
  "tokio",
 ]
@@ -4427,6 +4557,19 @@ checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
  "der",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb4dc4d33c68ec1f27d386b5610a351922656e1fdf5c05bbaad930cd1519479a"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -5631,7 +5774,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,9 @@ reqwest = { version = "0.12", default-features = false, features = [
     "http2",
     "macos-system-configuration",
 ] }
+rmcp = "0.2.1"
 rustls = { version = "0.23", features = ["aws-lc-rs"] }
+schemars = "0.8"
 serde = "1.0.219"
 serde-dynamic-string = { git = "https://github.com/grafbase/grafbase" }
 serde_json = "1.0"

--- a/crates/config/src/lib.rs
+++ b/crates/config/src/lib.rs
@@ -1,3 +1,7 @@
+//! Nexus configuration structures to map the nexus.toml configuration.
+
+#![deny(missing_docs)]
+
 mod loader;
 mod mcp;
 
@@ -7,37 +11,48 @@ use std::{
     path::{Path, PathBuf},
 };
 
-use mcp::McpConfig;
+pub use mcp::McpConfig;
 use serde::Deserialize;
 
+/// Main configuration structure for the Nexus application.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Config {
+    /// HTTP server configuration settings.
     #[serde(default)]
     pub server: ServerConfig,
+    /// Model Context Protocol configuration settings.
     #[serde(default)]
     pub mcp: McpConfig,
 }
 
 impl Config {
+    /// Load configuration from a file path.
     pub fn load<P: AsRef<Path>>(path: P) -> anyhow::Result<Config> {
         loader::load(path)
     }
 }
 
+/// HTTP server configuration settings.
 #[derive(Default, Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct ServerConfig {
+    /// The socket address the server should listen on.
     pub listen_address: Option<SocketAddr>,
+    /// TLS configuration for secure connections.
     pub tls: Option<TlsConfig>,
+    /// Health endpoint configuration.
     #[serde(default)]
     pub health: HealthConfig,
 }
 
+/// TLS configuration for secure connections.
 #[derive(Default, Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TlsConfig {
+    /// Path to the TLS certificate PEM file.
     pub certificate: PathBuf,
+    /// Path to the TLS private key PEM file.
     pub key: PathBuf,
 }
 
@@ -45,8 +60,11 @@ pub struct TlsConfig {
 #[derive(Clone, Debug, serde::Deserialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct HealthConfig {
+    /// Whether the health endpoint is enabled.
     pub enabled: bool,
+    /// The socket address the health endpoint should listen on.
     pub listen: Option<SocketAddr>,
+    /// The path for the health endpoint.
     pub path: Cow<'static, str>,
 }
 
@@ -74,7 +92,6 @@ mod tests {
 
             [mcp]
             enabled = false
-            protocol = "sse"
             path = "/mcp-path"
         "#};
 
@@ -95,7 +112,6 @@ mod tests {
             },
             mcp: McpConfig {
                 enabled: false,
-                protocol: Sse,
                 path: "/mcp-path",
             },
         }
@@ -119,7 +135,6 @@ mod tests {
             },
             mcp: McpConfig {
                 enabled: true,
-                protocol: StreamableHttp,
                 path: "/mcp",
             },
         }

--- a/crates/config/src/mcp.rs
+++ b/crates/config/src/mcp.rs
@@ -1,12 +1,13 @@
 use serde::Deserialize;
 
+/// Configuration for MCP (Model Context Protocol) settings.
 #[derive(Debug, Clone, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct McpConfig {
+    /// Whether MCP is enabled or disabled.
     #[serde(default = "default_enabled")]
     pub enabled: bool,
-    #[serde(default)]
-    pub protocol: McpProtocol,
+    /// The path for MCP endpoint.
     #[serde(default = "default_path")]
     pub path: String,
 }
@@ -15,7 +16,6 @@ impl Default for McpConfig {
     fn default() -> Self {
         Self {
             enabled: true,
-            protocol: McpProtocol::default(),
             path: "/mcp".to_string(),
         }
     }
@@ -27,13 +27,4 @@ fn default_enabled() -> bool {
 
 fn default_path() -> String {
     "/mcp".to_string()
-}
-
-#[derive(Default, Debug, Clone, Copy, Deserialize)]
-pub enum McpProtocol {
-    #[serde(rename = "sse")]
-    Sse,
-    #[serde(rename = "streamable-http")]
-    #[default]
-    StreamableHttp,
 }

--- a/crates/integration-tests/Cargo.toml
+++ b/crates/integration-tests/Cargo.toml
@@ -12,8 +12,10 @@ config.workspace = true
 indoc.workspace = true
 insta.workspace = true
 reqwest = { workspace = true, features = ["json"] }
+rmcp = { workspace = true, features = ["client", "reqwest", "transport-streamable-http-client"] }
 rustls.workspace = true
 serde = { workspace = true, features = ["derive"] }
+serde_json.workspace = true
 server.workspace = true
 tokio = { workspace = true, features = ["full"] }
 toml.workspace = true

--- a/crates/integration-tests/tests/integration_tests.rs
+++ b/crates/integration-tests/tests/integration_tests.rs
@@ -1,41 +1,144 @@
 use indoc::indoc;
 use integration_tests::*;
+use serde_json::json;
 
 #[tokio::test]
-async fn default_path() {
+async fn mcp_server_info() {
     let config = indoc! {r#"
         [mcp]
         enabled = true
     "#};
 
     let server = TestServer::start(config).await;
+    let mcp_client = server.mcp_client("/mcp").await;
 
-    let response = server.client.get("/mcp").await;
-    assert_eq!(response.status(), 200);
+    let server_info = mcp_client.get_server_info();
 
-    let body = response.text().await.unwrap();
-    insta::assert_snapshot!(body, @"<h1>Hello, World!</h1>");
+    // Verify basic server info
+    assert_eq!(server_info.protocol_version, rmcp::model::ProtocolVersion::V_2024_11_05);
+    assert!(server_info.capabilities.tools.is_some());
+
+    mcp_client.disconnect().await;
 }
 
 #[tokio::test]
-async fn custom_path() {
+async fn mcp_list_tools() {
     let config = indoc! {r#"
         [mcp]
         enabled = true
-        path = "/custom"
     "#};
 
     let server = TestServer::start(config).await;
+    let mcp_client = server.mcp_client("/mcp").await;
 
-    let response = server.client.get("/custom").await;
-    assert_eq!(response.status(), 200);
+    let tools_result = mcp_client.list_tools().await;
 
-    let body = response.text().await.unwrap();
-    insta::assert_snapshot!(body, @"<h1>Hello, World!</h1>");
+    insta::assert_json_snapshot!(&tools_result, @r#"
+    {
+      "tools": [
+        {
+          "name": "adder",
+          "description": "adds a and b together",
+          "inputSchema": {
+            "$schema": "http://json-schema.org/draft-07/schema#",
+            "title": "Request",
+            "type": "object",
+            "required": [
+              "a",
+              "b"
+            ],
+            "properties": {
+              "a": {
+                "type": "integer",
+                "format": "int32"
+              },
+              "b": {
+                "type": "integer",
+                "format": "int32"
+              }
+            }
+          },
+          "annotations": {
+            "readOnlyHint": true,
+            "destructiveHint": false,
+            "idempotentHint": true,
+            "openWorldHint": false
+          }
+        }
+      ]
+    }
+    "#);
+
+    mcp_client.disconnect().await;
 }
 
 #[tokio::test]
-async fn successful_tls_connection() {
+async fn mcp_call_adder_tool() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let server = TestServer::start(config).await;
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    // Call the adder tool with test values
+    let result = mcp_client.call_tool("adder", json!({ "a": 5, "b": 3 })).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    {
+      "content": [
+        {
+          "type": "text",
+          "text": "5 + 3 = 8"
+        }
+      ],
+      "isError": false
+    }
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn mcp_call_nonexistent_tool() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let server = TestServer::start(config).await;
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    // Try to call a tool that doesn't exist
+    let error = mcp_client.call_tool_expect_error("nonexistent", json!({})).await;
+
+    insta::assert_snapshot!(error.to_string(), @"Mcp error: -32602: Unknown tool 'nonexistent'");
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn mcp_custom_path() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+        path = "/custom-mcp"
+    "#};
+
+    let server = TestServer::start(config).await;
+    let mcp_client = server.mcp_client("/custom-mcp").await;
+
+    // Should be able to connect and list tools on custom path
+    let tools_result = mcp_client.list_tools().await;
+    assert_eq!(tools_result.tools.len(), 1);
+    assert_eq!(tools_result.tools[0].name, "adder");
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn mcp_with_tls() {
     let config = indoc! {r#"
         [server]
         [server.tls]
@@ -47,16 +150,25 @@ async fn successful_tls_connection() {
     "#};
 
     let server = TestServer::start(config).await;
+    let mcp_client = server.mcp_client("/mcp").await;
 
-    let response = server.client.get("/mcp").await;
-    assert_eq!(response.status(), 200);
+    // Should work over TLS
+    let tools_result = mcp_client.list_tools().await;
+    assert_eq!(tools_result.tools.len(), 1);
 
-    let body = response.text().await.unwrap();
-    insta::assert_snapshot!(body, @"<h1>Hello, World!</h1>");
+    // Test calling the tool over TLS
+    let result = mcp_client.call_tool("adder", json!({ "a": 7, "b": 2 })).await;
+
+    assert!(result.is_error != Some(true));
+    // Check if the content contains the expected text
+    let content_text = format!("{:?}", result.content[0]);
+    assert!(content_text.contains("7 + 2 = 9"));
+
+    mcp_client.disconnect().await;
 }
 
 #[tokio::test]
-async fn health_endpoint_enabled() {
+async fn health_endpoint_still_works() {
     let config = indoc! {r#"
         [server]
         [server.health]
@@ -68,6 +180,7 @@ async fn health_endpoint_enabled() {
 
     let server = TestServer::start(config).await;
 
+    // Health endpoint should still work alongside MCP
     let response = server.client.get("/health").await;
     assert_eq!(response.status(), 200);
 

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -1,0 +1,30 @@
+[package]
+name = "mcp"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+keywords.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow = { workspace = true, features = ["backtrace"] }
+axum.workspace = true
+config.workspace = true
+futures-util.workspace = true
+http.workspace = true
+rmcp = { workspace = true, features = [
+    "transport-sse-server",
+    "transport-streamable-http-server",
+    "client",
+    "reqwest",
+    "transport-streamable-http-client",
+    "auth",
+    "transport-io",
+] }
+schemars.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+
+[lints]
+workspace = true

--- a/crates/mcp/src/lib.rs
+++ b/crates/mcp/src/lib.rs
@@ -1,0 +1,30 @@
+//! MCP (Multi-Client Protocol) library for routing HTTP requests to multiple MCP backends.
+
+#![deny(missing_docs)]
+
+mod server;
+mod tool;
+
+use std::{sync::Arc, time::Duration};
+
+use axum::Router;
+use config::McpConfig;
+use rmcp::transport::{
+    StreamableHttpServerConfig, StreamableHttpService, streamable_http_server::session::never::NeverSessionManager,
+};
+
+/// Creates an axum router for MCP.
+pub fn router(config: &McpConfig) -> anyhow::Result<Router> {
+    let mcp_server = server::McpServer::new()?;
+
+    let service = StreamableHttpService::new(
+        move || Ok(mcp_server.clone()),
+        Arc::new(NeverSessionManager::default()),
+        StreamableHttpServerConfig {
+            sse_keep_alive: Some(Duration::from_secs(5)),
+            stateful_mode: false,
+        },
+    );
+
+    Ok(Router::new().route_service(&config.path, service))
+}

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -1,0 +1,74 @@
+use std::sync::Arc;
+
+use rmcp::{
+    RoleServer, ServerHandler,
+    model::{
+        CallToolRequestParam, CallToolResult, ErrorCode, ErrorData, Implementation, ListToolsResult,
+        PaginatedRequestParam, ProtocolVersion, ServerCapabilities, ServerInfo,
+    },
+    service::RequestContext,
+};
+
+use crate::tool::{RmcpTool, adder::Adder};
+
+#[derive(Clone)]
+pub(crate) struct McpServer(Arc<McpServerInner>);
+
+pub(crate) struct McpServerInner {
+    info: ServerInfo,
+    tools: Vec<Box<dyn RmcpTool>>,
+}
+
+impl std::ops::Deref for McpServer {
+    type Target = McpServerInner;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl McpServer {
+    pub(crate) fn new() -> anyhow::Result<Self> {
+        Ok(Self(Arc::new(McpServerInner {
+            info: ServerInfo {
+                protocol_version: ProtocolVersion::V_2024_11_05,
+                capabilities: ServerCapabilities::builder().enable_tools().build(),
+                server_info: Implementation::from_build_env(),
+                instructions: None,
+            },
+            tools: vec![Box::new(Adder)],
+        })))
+    }
+}
+
+impl ServerHandler for McpServer {
+    fn get_info(&self) -> ServerInfo {
+        self.info.clone()
+    }
+
+    async fn list_tools(
+        &self,
+        _: Option<PaginatedRequestParam>,
+        _: RequestContext<RoleServer>,
+    ) -> Result<ListToolsResult, ErrorData> {
+        Ok(ListToolsResult {
+            next_cursor: None,
+            tools: self.tools.iter().map(|tool| tool.to_tool()).collect(),
+        })
+    }
+
+    async fn call_tool(
+        &self,
+        CallToolRequestParam { name, arguments }: CallToolRequestParam,
+        context: RequestContext<RoleServer>,
+    ) -> Result<CallToolResult, ErrorData> {
+        if let Some(tool) = self.tools.iter().find(|tool| tool.name() == name) {
+            return tool.call(arguments, context).await;
+        }
+
+        Err(ErrorData::new(
+            ErrorCode::INVALID_PARAMS,
+            format!("Unknown tool '{name}'"),
+            None,
+        ))
+    }
+}

--- a/crates/mcp/src/tool.rs
+++ b/crates/mcp/src/tool.rs
@@ -1,0 +1,74 @@
+pub mod adder;
+
+use std::borrow::Cow;
+
+use futures_util::future::BoxFuture;
+use rmcp::{
+    RoleServer,
+    model::{CallToolResult, ErrorCode, ErrorData, JsonObject, ToolAnnotations},
+    service::RequestContext,
+};
+use schemars::{JsonSchema, schema_for};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+
+pub(crate) trait Tool: Send + Sync + 'static {
+    type Parameters: DeserializeOwned + JsonSchema;
+
+    fn name() -> &'static str;
+    fn description(&self) -> Cow<'_, str>;
+    fn annotations(&self) -> ToolAnnotations;
+
+    fn call(
+        &self,
+        parameters: Self::Parameters,
+        http_headers: Option<http::HeaderMap>,
+    ) -> impl Future<Output = anyhow::Result<CallToolResult>> + Send;
+}
+
+pub(crate) trait RmcpTool: Send + Sync + 'static {
+    fn name(&self) -> &str;
+    fn to_tool(&self) -> rmcp::model::Tool;
+
+    fn call(
+        &self,
+        parameters: Option<JsonObject>,
+        context: RequestContext<RoleServer>,
+    ) -> BoxFuture<'_, Result<CallToolResult, ErrorData>>;
+}
+
+impl<T: Tool> RmcpTool for T {
+    fn name(&self) -> &str {
+        T::name()
+    }
+
+    fn to_tool(&self) -> rmcp::model::Tool {
+        let Value::Object(schema) = serde_json::to_value(schema_for!(<T as Tool>::Parameters)).unwrap() else {
+            unreachable!()
+        };
+
+        rmcp::model::Tool::new(self.name().to_string(), self.description().into_owned(), schema)
+            .annotate(self.annotations())
+    }
+
+    fn call(
+        &self,
+        parameters: Option<JsonObject>,
+        mut context: RequestContext<RoleServer>,
+    ) -> BoxFuture<'_, Result<CallToolResult, ErrorData>> {
+        let http_headers = context
+            .extensions
+            .get_mut::<http::request::Parts>()
+            .map(|parts| std::mem::take(&mut parts.headers));
+
+        Box::pin(async move {
+            let parameters: T::Parameters = serde_json::from_value(Value::Object(parameters.unwrap_or_default()))
+                .map_err(|err| ErrorData::new(ErrorCode::INVALID_PARAMS, err.to_string(), None))?;
+
+            match Tool::call(self, parameters, http_headers).await {
+                Ok(data) => Ok(data),
+                Err(err) => Err(ErrorData::new(ErrorCode::INTERNAL_ERROR, err.to_string(), None)),
+            }
+        })
+    }
+}

--- a/crates/mcp/src/tool/adder.rs
+++ b/crates/mcp/src/tool/adder.rs
@@ -1,0 +1,45 @@
+//! A simple adder tool just for demonstration. Let's remove this when we get actual tools.
+
+use std::borrow::Cow;
+
+use http::HeaderMap;
+use rmcp::{
+    model::{CallToolResult, Content, ToolAnnotations},
+    schemars::JsonSchema,
+};
+
+use super::Tool;
+
+#[derive(Debug, Clone, PartialEq, Eq, JsonSchema, serde::Deserialize)]
+pub struct Request {
+    pub a: i32,
+    pub b: i32,
+}
+
+pub struct Adder;
+
+impl Tool for Adder {
+    type Parameters = Request;
+
+    fn name() -> &'static str {
+        "adder"
+    }
+
+    fn description(&self) -> Cow<'_, str> {
+        "adds a and b together".into()
+    }
+
+    fn annotations(&self) -> ToolAnnotations {
+        ToolAnnotations::new()
+            .idempotent(true)
+            .read_only(true)
+            .destructive(false)
+            .open_world(false)
+    }
+
+    async fn call(&self, Request { a, b }: Self::Parameters, _: Option<HeaderMap>) -> anyhow::Result<CallToolResult> {
+        let content = Content::text(format!("{a} + {b} = {}", a + b));
+
+        Ok(CallToolResult::success(vec![content]))
+    }
+}

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -8,12 +8,13 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["backtrace"] }
 axum = { workspace = true, features = ["macros", "json", "http2"] }
 axum-server.workspace = true
 config.workspace = true
 http.workspace = true
 log = { workspace = true, features = ["kv"] }
+mcp = { version = "0.1.0", path = "../mcp" }
 serde.workspace = true
 tokio = { workspace = true, features = ["signal"] }
 

--- a/nexus/Cargo.toml
+++ b/nexus/Cargo.toml
@@ -8,7 +8,7 @@ keywords.workspace = true
 repository.workspace = true
 
 [dependencies]
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["backtrace"] }
 clap = { workspace = true, features = ["derive", "env"] }
 config.workspace = true
 logforth = { workspace = true, features = ["append-fastrace", "colored", "diagnostic-fastrace", "layout-json"] }


### PR DESCRIPTION
This adds a dumb but operational mcp server with an adder tool, so we can implement the testing facilities and continue to actually implement the mcp server we want.

<img width="600" height="624" alt="image" src="https://github.com/user-attachments/assets/870b3ee8-cc3c-46c8-a189-b5b1ca6a7dbe" />