### PR TITLE
chore: use the 'latest' protocol

### DIFF
--- a/crates/integration-tests/tests/integration_tests.rs
+++ b/crates/integration-tests/tests/integration_tests.rs
@@ -14,12 +14,9 @@ async fn mcp_server_info() {
 
     let server = TestServer::builder().build(config).await;
     let mcp_client = server.mcp_client("/mcp").await;
-
     let server_info = mcp_client.get_server_info();
 
-    // Verify basic server info
-    assert_eq!(server_info.protocol_version, rmcp::model::ProtocolVersion::V_2024_11_05);
-    assert!(server_info.capabilities.tools.is_some());
+    insta::assert_json_snapshot!(&server_info.protocol_version, @r#""2025-03-26""#);
 
     mcp_client.disconnect().await;
 }

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -33,7 +33,7 @@ impl McpServer {
 
         let inner = McpServerInner {
             info: ServerInfo {
-                protocol_version: ProtocolVersion::V_2024_11_05,
+                protocol_version: ProtocolVersion::V_2025_03_26,
                 capabilities: ServerCapabilities::builder().enable_tools().build(),
                 server_info: Implementation::from_build_env(),
                 instructions: None,


### PR DESCRIPTION
Nothing newer in rmcp so far.