### PR TITLE
feat(gb-9324): search and execute

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -581,6 +581,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
 
 [[package]]
+name = "bitpacking"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c1d3e2bfd8d06048a179f7b17afc3188effa10385e7b00dc65af6aae732ea92"
+dependencies = [
+ "crunchy",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -609,6 +618,31 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.0",
  "piper",
+]
+
+[[package]]
+name = "bon"
+version = "3.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f61138465baf186c63e8d9b6b613b508cd832cba4ce93cf37ce5f096f91ac1a6"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40d1dad34aa19bf02295382f08d9bc40651585bd497266831d40ee6296fb49ca"
+dependencies = [
+ "darling 0.20.11",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -683,6 +717,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "census"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f4c707c6a209cbe82d10abd08e1ea8995e9ea937d2550646e02798948992be0"
 
 [[package]]
 name = "cexpr"
@@ -892,6 +932,15 @@ name = "const_fn"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f8a2ca5ac02d09563609681103aada9e1777d54fc57a5acd7a41404f9c93b6e"
+
+[[package]]
+name = "convert_case"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baaaa0ecca5b51987b9423ccdc971514dd8b0bb7b4060b983d3664dad3f1f89f"
+dependencies = [
+ "unicode-segmentation",
+]
 
 [[package]]
 name = "cookie"
@@ -1332,6 +1381,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "downcast-rs"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea8a8b81cacc08888170eef4d13b775126db426d0b348bee9d18c2c1eaf123cf"
+
+[[package]]
 name = "dtor"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1547,6 +1602,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastdivide"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afc2bd4d5a73106dd53d10d73d3401c2f32730ba2c0b93ddb888a8983680471"
+
+[[package]]
 name = "fastrace"
 version = "0.7.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1652,6 +1713,16 @@ checksum = "88d7be93788013f265201256d58f04936a8079ad5dc898743aa20525f503b683"
 dependencies = [
  "autocfg",
  "tokio",
+]
+
+[[package]]
+name = "fs4"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7e180ac76c23b45e767bd7ae9579bc0bb458618c4bc71835926e098e61d15f8"
+dependencies = [
+ "rustix 0.38.44",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2220,6 +2291,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "htmlescape"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9025058dae765dee5070ec375f591e2ba14638c63feff74f13805a72e523163"
+
+[[package]]
 name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2368,6 +2445,15 @@ dependencies = [
  "tower-service",
  "tracing",
  "windows-registry",
+]
+
+[[package]]
+name = "hyperloglogplus"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "621debdf94dcac33e50475fdd76d34d5ea9c0362a834b9db08c3024696c1fbe3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2779,6 +2865,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
+name = "levenshtein_automata"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c2cdeb66e45e9f36bfad5bbdb4d2384e70936afbee843c6f6543f0c551ebb25"
+
+[[package]]
 name = "libc"
 version = "0.2.174"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2894,6 +2986,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.12.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+dependencies = [
+ "hashbrown 0.15.4",
+]
+
+[[package]]
 name = "lru-cache"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2936,9 +3037,26 @@ dependencies = [
  "anyhow",
  "axum",
  "config",
+ "convert_case",
+ "futures-util",
+ "http",
+ "indoc",
+ "itertools 0.14.0",
  "log",
  "reqwest",
  "rmcp",
+ "schemars 1.0.4",
+ "serde",
+ "tantivy",
+]
+
+[[package]]
+name = "measure_time"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51c55d61e72fc3ab704396c5fa16f4c184db37978ae4e94ca8959693a235fc0e"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -2946,6 +3064,15 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "483758ad303d734cec05e5c12b41d7e93e6a6390c5e9dae6bdeb7c1259012d28"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "miette"
@@ -3049,6 +3176,12 @@ dependencies = [
  "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "murmurhash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2195bf6aa996a481483b29d62a7663eed3fe39600c460e323f8ff41e90bdd89b"
 
 [[package]]
 name = "nexus"
@@ -3180,6 +3313,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
 
 [[package]]
+name = "oneshot"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ce411919553d3f9fa53a0880544cda985a112117a0444d5ff1e870a893d6ea"
+
+[[package]]
 name = "oorandom"
 version = "11.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3226,6 +3365,15 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "ownedbytes"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbd56f7631767e61784dc43f8580f403f4475bd4aaa4da003e6295e1bab4a7e"
+dependencies = [
+ "stable_deref_trait",
+]
 
 [[package]]
 name = "owo-colors"
@@ -3790,6 +3938,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_distr"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32cb0b9bc82b0a0876c2dd994a7e7a2683d3e7390ca40e6886785ef0c7e3ee31"
+dependencies = [
+ "num-traits",
+ "rand 0.8.5",
+]
+
+[[package]]
 name = "rand_hc"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4043,6 +4201,16 @@ name = "rtrb"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad8388ea1a9e0ea807e442e8263a699e7edcb320ecbcd21b4fa8ff859acce3ba"
+
+[[package]]
+name = "rust-stemmers"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e46a2036019fdb888131db7a4c847a1063a7493f971ed94ea82c67eada63ca54"
+dependencies = [
+ "serde",
+ "serde_derive",
+]
 
 [[package]]
 name = "rustc-demangle"
@@ -4580,6 +4748,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sketches-ddsketch"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1e9a774a6c28142ac54bb25d25562e6bcf957493a184f15ad4eebccb23e410a"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4932,6 +5109,165 @@ checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
+]
+
+[[package]]
+name = "tantivy"
+version = "0.24.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64a966cb0e76e311f09cf18507c9af192f15d34886ee43d7ba7c7e3803660c43"
+dependencies = [
+ "aho-corasick",
+ "arc-swap",
+ "base64 0.22.1",
+ "bitpacking",
+ "bon",
+ "byteorder",
+ "census",
+ "crc32fast",
+ "crossbeam-channel",
+ "downcast-rs",
+ "fastdivide",
+ "fnv",
+ "fs4",
+ "htmlescape",
+ "hyperloglogplus",
+ "itertools 0.14.0",
+ "levenshtein_automata",
+ "log",
+ "lru",
+ "lz4_flex",
+ "measure_time",
+ "memmap2",
+ "once_cell",
+ "oneshot",
+ "rayon",
+ "regex",
+ "rust-stemmers",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "sketches-ddsketch",
+ "smallvec",
+ "tantivy-bitpacker",
+ "tantivy-columnar",
+ "tantivy-common",
+ "tantivy-fst",
+ "tantivy-query-grammar",
+ "tantivy-stacker",
+ "tantivy-tokenizer-api",
+ "tempfile",
+ "thiserror 2.0.12",
+ "time 0.3.41",
+ "uuid",
+ "winapi",
+]
+
+[[package]]
+name = "tantivy-bitpacker"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1adc286a39e089ae9938935cd488d7d34f14502544a36607effd2239ff0e2494"
+dependencies = [
+ "bitpacking",
+]
+
+[[package]]
+name = "tantivy-columnar"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6300428e0c104c4f7db6f95b466a6f5c1b9aece094ec57cdd365337908dc7344"
+dependencies = [
+ "downcast-rs",
+ "fastdivide",
+ "itertools 0.14.0",
+ "serde",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-sstable",
+ "tantivy-stacker",
+]
+
+[[package]]
+name = "tantivy-common"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91b6ea6090ce03dc72c27d0619e77185d26cc3b20775966c346c6d4f7e99d7f"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "ownedbytes",
+ "serde",
+ "time 0.3.41",
+]
+
+[[package]]
+name = "tantivy-fst"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d60769b80ad7953d8a7b2c70cdfe722bbcdcac6bccc8ac934c40c034d866fc18"
+dependencies = [
+ "byteorder",
+ "regex-syntax 0.8.5",
+ "utf8-ranges",
+]
+
+[[package]]
+name = "tantivy-query-grammar"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e810cdeeebca57fc3f7bfec5f85fdbea9031b2ac9b990eb5ff49b371d52bbe6a"
+dependencies = [
+ "nom",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "tantivy-sstable"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709f22c08a4c90e1b36711c1c6cad5ae21b20b093e535b69b18783dd2cb99416"
+dependencies = [
+ "futures-util",
+ "itertools 0.14.0",
+ "tantivy-bitpacker",
+ "tantivy-common",
+ "tantivy-fst",
+ "zstd",
+]
+
+[[package]]
+name = "tantivy-stacker"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bcdebb267671311d1e8891fd9d1301803fdb8ad21ba22e0a30d0cab49ba59c1"
+dependencies = [
+ "murmurhash32",
+ "rand_distr",
+ "tantivy-common",
+]
+
+[[package]]
+name = "tantivy-tokenizer-api"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfa942fcee81e213e09715bbce8734ae2180070b97b33839a795ba1de201547d"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
+dependencies = [
+ "fastrand 2.3.0",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.7",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5540,6 +5876,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ axum = "0.8.4"
 axum-server = { version = "0.7", features = ["tls-rustls"] }
 clap = "4.5.41"
 config = { path = "crates/config" }
+convert_case = "0.8.0"
 ctor = "0.4.2"
 fastrace = "0.7.14"
 futures-util = "0.3.31"
@@ -40,6 +41,7 @@ serde-dynamic-string = { git = "https://github.com/grafbase/grafbase" }
 serde_json = "1.0"
 serde_with = "3.14.0"
 server = { path = "crates/server" }
+tantivy = "0.24.2"
 temp-env = "0.3.6"
 thiserror = "2.0.12"
 tokio = { version = "1.46.1", default-features = false }

--- a/crates/integration-tests/tests/integration_tests.rs
+++ b/crates/integration-tests/tests/integration_tests.rs
@@ -209,7 +209,57 @@ async fn no_tools_by_default() {
     // Should have no tools when no services are configured
     insta::assert_json_snapshot!(&tools_result, @r#"
     {
-      "tools": []
+      "tools": [
+        {
+          "name": "search",
+          "description": "Search for relevant tools. A list of matching tools with their\nscore is returned with a map of input fields and their types.\n\nUsing this information, you can call the execute tool with the\nname of the tool you want to execute, and defining the input\nparameters.\n",
+          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "SearchParameters",
+            "type": "object",
+            "properties": {
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "keywords"
+            ]
+          },
+          "annotations": {
+            "readOnlyHint": true
+          }
+        },
+        {
+          "name": "execute",
+          "description": "Executes a tool with the given parameters. Before using, you must call the\nsearch function to retrieve the tools you need for your task. If you do not\nknow how to call this tool, call search first.\n\nThe tool name and parameters are specified in the request body. The tool name\nmust be a string, and the parameters must be a map of strings to JSON values.\n",
+          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "ExecuteParameters",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "arguments": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          },
+          "annotations": {
+            "destructiveHint": true,
+            "openWorldHint": true
+          }
+        }
+      ]
     }
     "#);
 

--- a/crates/integration-tests/tests/streamable_http/mod.rs
+++ b/crates/integration-tests/tests/streamable_http/mod.rs
@@ -1,10 +1,10 @@
-use crate::tools::{AdderTool, FailingTool};
+use crate::tools::{AdderTool, CalculatorTool, FailingTool, FileSystemTool, TextProcessorTool};
 use indoc::indoc;
 use integration_tests::{TestServer, TestService, get_test_cert_paths};
 use serde_json::json;
 
 #[tokio::test]
-async fn service_with_single_tool() {
+async fn list_tools() {
     let config = indoc! {r#"
         [mcp]
         enabled = true
@@ -19,70 +19,61 @@ async fn service_with_single_tool() {
 
     let mcp_client = server.mcp_client("/mcp").await;
 
-    // Should list the adder tool with proper naming
     let tools_result = mcp_client.list_tools().await;
 
     insta::assert_json_snapshot!(&tools_result, @r#"
     {
       "tools": [
         {
-          "name": "math_service__adder",
-          "description": "Adds two numbers together",
+          "name": "search",
+          "description": "Search for relevant tools. A list of matching tools with their\nscore is returned with a map of input fields and their types.\n\nUsing this information, you can call the execute tool with the\nname of the tool you want to execute, and defining the input\nparameters.\n",
           "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "SearchParameters",
             "type": "object",
             "properties": {
-              "a": {
-                "type": "number",
-                "description": "First number to add"
-              },
-              "b": {
-                "type": "number",
-                "description": "Second number to add"
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": [
-              "a",
-              "b"
+              "keywords"
             ]
+          },
+          "annotations": {
+            "readOnlyHint": true
+          }
+        },
+        {
+          "name": "execute",
+          "description": "Executes a tool with the given parameters. Before using, you must call the\nsearch function to retrieve the tools you need for your task. If you do not\nknow how to call this tool, call search first.\n\nThe tool name and parameters are specified in the request body. The tool name\nmust be a string, and the parameters must be a map of strings to JSON values.\n",
+          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "ExecuteParameters",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "arguments": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          },
+          "annotations": {
+            "destructiveHint": true,
+            "openWorldHint": true
           }
         }
       ]
-    }
-    "#);
-
-    mcp_client.disconnect().await;
-}
-
-#[tokio::test]
-async fn call_tool_success() {
-    let config = indoc! {r#"
-        [mcp]
-        enabled = true
-    "#};
-
-    let mut test_service = TestService::streamable_http("math_service".to_string());
-    test_service.add_tool(AdderTool).await;
-
-    let mut builder = TestServer::builder();
-    builder.spawn_service(test_service).await;
-    let server = builder.build(config).await;
-
-    let mcp_client = server.mcp_client("/mcp").await;
-
-    // Call the adder tool with test values
-    let result = mcp_client
-        .call_tool("math_service__adder", json!({ "a": 5, "b": 3 }))
-        .await;
-
-    insta::assert_json_snapshot!(result, @r#"
-    {
-      "content": [
-        {
-          "type": "text",
-          "text": "5 + 3 = 8"
-        }
-      ],
-      "isError": false
     }
     "#);
 
@@ -105,9 +96,8 @@ async fn call_tool_success_autodetect() {
 
     let mcp_client = server.mcp_client("/mcp").await;
 
-    // Call the adder tool with test values
     let result = mcp_client
-        .call_tool("math_service__adder", json!({ "a": 5, "b": 3 }))
+        .execute("math_service__adder", json!({ "a": 5, "b": 3 }))
         .await;
 
     insta::assert_json_snapshot!(result, @r#"
@@ -141,9 +131,8 @@ async fn call_tool_with_decimals() {
 
     let mcp_client = server.mcp_client("/mcp").await;
 
-    // Call the adder tool with decimal values
     let result = mcp_client
-        .call_tool("math_service__adder", json!({ "a": 2.5, "b": 1.5 }))
+        .execute("math_service__adder", json!({ "a": 2.5, "b": 1.5 }))
         .await;
 
     insta::assert_json_snapshot!(result, @r#"
@@ -176,9 +165,7 @@ async fn call_nonexistent_tool() {
     let server = builder.build(config).await;
 
     let mcp_client = server.mcp_client("/mcp").await;
-
-    // Try to call a tool that doesn't exist
-    let error = mcp_client.call_tool_expect_error("nonexistent_tool", json!({})).await;
+    let error = mcp_client.execute_expect_error("nonexistent_tool", json!({})).await;
 
     insta::assert_snapshot!(error.to_string(), @"Mcp error: -32602: Unknown tool: nonexistent_tool");
 
@@ -197,16 +184,15 @@ async fn call_tool_wrong_server_prefix() {
 
     let mut builder = TestServer::builder();
     builder.spawn_service(test_service).await;
-    let server = builder.build(config).await;
 
+    let server = builder.build(config).await;
     let mcp_client = server.mcp_client("/mcp").await;
 
-    // Try to call the tool with wrong server prefix
     let error = mcp_client
-        .call_tool_expect_error("wrong_service__adder", json!({ "a": 1, "b": 2 }))
+        .execute_expect_error("mtah_service__adder", json!({ "a": 1, "b": 2 }))
         .await;
 
-    insta::assert_snapshot!(error.to_string(), @"Mcp error: -32602: Unknown tool: wrong_service__adder");
+    insta::assert_snapshot!(error.to_string(), @"Mcp error: -32602: Unknown tool: mtah_service__adder. Did you mean: math_service__adder");
 
     mcp_client.disconnect().await;
 }
@@ -223,16 +209,19 @@ async fn call_tool_invalid_arguments() {
 
     let mut builder = TestServer::builder();
     builder.spawn_service(test_service).await;
-    let server = builder.build(config).await;
 
+    let server = builder.build(config).await;
     let mcp_client = server.mcp_client("/mcp").await;
 
-    // Call the tool with missing argument
-    let error = mcp_client
-        .call_tool_expect_error("math_service__adder", json!({ "a": 5 }))
-        .await;
+    let arguments = json!({
+        "name": "math_service__adder",
+        "arguments": {
+            "a": 5,
+        }
+    });
 
-    insta::assert_snapshot!(error.to_string(), @"Mcp error: -32603: Mcp error: -32602: Missing or invalid parameter 'b'");
+    let error = mcp_client.execute_expect_error("execute", arguments).await;
+    insta::assert_snapshot!(error.to_string(), @"Mcp error: -32602: Unknown tool: execute");
 
     mcp_client.disconnect().await;
 }
@@ -253,12 +242,9 @@ async fn call_tool_no_arguments() {
 
     let mcp_client = server.mcp_client("/mcp").await;
 
-    // Call the tool with no arguments
-    let error = mcp_client
-        .call_tool_expect_error("math_service__adder", json!({}))
-        .await;
+    let error = mcp_client.execute_expect_error("math_service__adder", json!({})).await;
 
-    insta::assert_snapshot!(error.to_string(), @"Mcp error: -32603: Mcp error: -32602: Missing or invalid parameter 'a'");
+    insta::assert_snapshot!(error.to_string(), @"Mcp error: -32602: Missing or invalid parameter 'a'");
 
     mcp_client.disconnect().await;
 }
@@ -270,11 +256,9 @@ async fn multiple_services_multiple_tools() {
         enabled = true
     "#};
 
-    // Create first service with adder tool
     let mut math_service = TestService::streamable_http("math_service".to_string());
     math_service.add_tool(AdderTool).await;
 
-    // Create second service with failing tool
     let mut error_service = TestService::streamable_http("error_service".to_string());
     error_service.add_tool(FailingTool).await;
 
@@ -286,48 +270,66 @@ async fn multiple_services_multiple_tools() {
 
     let mcp_client = server.mcp_client("/mcp").await;
 
-    // Should list tools from both services
     let tools_result = mcp_client.list_tools().await;
 
     insta::assert_json_snapshot!(&tools_result, @r#"
     {
       "tools": [
         {
-          "name": "error_service__failing_tool",
-          "description": "A tool that always fails for testing error handling",
+          "name": "search",
+          "description": "Search for relevant tools. A list of matching tools with their\nscore is returned with a map of input fields and their types.\n\nUsing this information, you can call the execute tool with the\nname of the tool you want to execute, and defining the input\nparameters.\n",
           "inputSchema": {
-            "type": "object",
-            "properties": {}
-          }
-        },
-        {
-          "name": "math_service__adder",
-          "description": "Adds two numbers together",
-          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "SearchParameters",
             "type": "object",
             "properties": {
-              "a": {
-                "type": "number",
-                "description": "First number to add"
-              },
-              "b": {
-                "type": "number",
-                "description": "Second number to add"
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": [
-              "a",
-              "b"
+              "keywords"
             ]
+          },
+          "annotations": {
+            "readOnlyHint": true
+          }
+        },
+        {
+          "name": "execute",
+          "description": "Executes a tool with the given parameters. Before using, you must call the\nsearch function to retrieve the tools you need for your task. If you do not\nknow how to call this tool, call search first.\n\nThe tool name and parameters are specified in the request body. The tool name\nmust be a string, and the parameters must be a map of strings to JSON values.\n",
+          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "ExecuteParameters",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "arguments": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          },
+          "annotations": {
+            "destructiveHint": true,
+            "openWorldHint": true
           }
         }
       ]
     }
     "#);
 
-    // Test calling tools from both services
     let add_result = mcp_client
-        .call_tool("math_service__adder", json!({ "a": 10, "b": 20 }))
+        .execute("math_service__adder", json!({ "a": 10, "b": 20 }))
         .await;
 
     insta::assert_json_snapshot!(&add_result, @r#"
@@ -343,10 +345,10 @@ async fn multiple_services_multiple_tools() {
     "#);
 
     let fail_error = mcp_client
-        .call_tool_expect_error("error_service__failing_tool", json!({}))
+        .execute_expect_error("error_service__failing_tool", json!({}))
         .await;
 
-    insta::assert_snapshot!(fail_error.to_string(), @"Mcp error: -32603: Mcp error: -32000: This tool always fails({\"reason\":\"intentional_failure\"})");
+    insta::assert_snapshot!(fail_error.to_string(), @r#"Mcp error: -32000: This tool always fails({"reason":"intentional_failure"})"#);
 
     mcp_client.disconnect().await;
 }
@@ -368,31 +370,58 @@ async fn test_custom_mcp_path_with_tools() {
 
     let mcp_client = server.mcp_client("/custom-mcp").await;
 
-    // Should be able to connect and use tools on custom path
     let tools_result = mcp_client.list_tools().await;
 
     insta::assert_json_snapshot!(&tools_result, @r#"
     {
       "tools": [
         {
-          "name": "math_service__adder",
-          "description": "Adds two numbers together",
+          "name": "search",
+          "description": "Search for relevant tools. A list of matching tools with their\nscore is returned with a map of input fields and their types.\n\nUsing this information, you can call the execute tool with the\nname of the tool you want to execute, and defining the input\nparameters.\n",
           "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "SearchParameters",
             "type": "object",
             "properties": {
-              "a": {
-                "type": "number",
-                "description": "First number to add"
-              },
-              "b": {
-                "type": "number",
-                "description": "Second number to add"
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": [
-              "a",
-              "b"
+              "keywords"
             ]
+          },
+          "annotations": {
+            "readOnlyHint": true
+          }
+        },
+        {
+          "name": "execute",
+          "description": "Executes a tool with the given parameters. Before using, you must call the\nsearch function to retrieve the tools you need for your task. If you do not\nknow how to call this tool, call search first.\n\nThe tool name and parameters are specified in the request body. The tool name\nmust be a string, and the parameters must be a map of strings to JSON values.\n",
+          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "ExecuteParameters",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "arguments": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          },
+          "annotations": {
+            "destructiveHint": true,
+            "openWorldHint": true
           }
         }
       ]
@@ -400,7 +429,7 @@ async fn test_custom_mcp_path_with_tools() {
     "#);
 
     let result = mcp_client
-        .call_tool("math_service__adder", json!({ "a": 7, "b": 2 }))
+        .execute("math_service__adder", json!({ "a": 7, "b": 2 }))
         .await;
 
     insta::assert_json_snapshot!(&result, @r#"
@@ -435,44 +464,69 @@ async fn tools_with_tls() {
 
     let mut builder = TestServer::builder();
     builder.spawn_service(test_service).await;
+
     let server = builder.build(config).await;
-
     let mcp_client = server.mcp_client("/mcp").await;
-
-    // Should work over TLS
     let tools_result = mcp_client.list_tools().await;
 
     insta::assert_json_snapshot!(&tools_result, @r#"
     {
       "tools": [
         {
-          "name": "math_service__adder",
-          "description": "Adds two numbers together",
+          "name": "search",
+          "description": "Search for relevant tools. A list of matching tools with their\nscore is returned with a map of input fields and their types.\n\nUsing this information, you can call the execute tool with the\nname of the tool you want to execute, and defining the input\nparameters.\n",
           "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "SearchParameters",
             "type": "object",
             "properties": {
-              "a": {
-                "type": "number",
-                "description": "First number to add"
-              },
-              "b": {
-                "type": "number",
-                "description": "Second number to add"
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
               }
             },
             "required": [
-              "a",
-              "b"
+              "keywords"
             ]
+          },
+          "annotations": {
+            "readOnlyHint": true
+          }
+        },
+        {
+          "name": "execute",
+          "description": "Executes a tool with the given parameters. Before using, you must call the\nsearch function to retrieve the tools you need for your task. If you do not\nknow how to call this tool, call search first.\n\nThe tool name and parameters are specified in the request body. The tool name\nmust be a string, and the parameters must be a map of strings to JSON values.\n",
+          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "ExecuteParameters",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "arguments": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          },
+          "annotations": {
+            "destructiveHint": true,
+            "openWorldHint": true
           }
         }
       ]
     }
     "#);
 
-    // Test calling the tool over TLS
     let result = mcp_client
-        .call_tool("math_service__adder", json!({ "a": 7, "b": 2 }))
+        .execute("math_service__adder", json!({ "a": 7, "b": 2 }))
         .await;
 
     insta::assert_json_snapshot!(result, @r#"
@@ -507,13 +561,105 @@ async fn tls_downstream_service() {
 
     let mcp_client = server.mcp_client("/mcp").await;
 
-    // Verify the tool is listed correctly
     let tools_result = mcp_client.list_tools().await;
     insta::assert_json_snapshot!(&tools_result, @r#"
     {
       "tools": [
         {
-          "name": "tls_http_service__adder",
+          "name": "search",
+          "description": "Search for relevant tools. A list of matching tools with their\nscore is returned with a map of input fields and their types.\n\nUsing this information, you can call the execute tool with the\nname of the tool you want to execute, and defining the input\nparameters.\n",
+          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "SearchParameters",
+            "type": "object",
+            "properties": {
+              "keywords": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              }
+            },
+            "required": [
+              "keywords"
+            ]
+          },
+          "annotations": {
+            "readOnlyHint": true
+          }
+        },
+        {
+          "name": "execute",
+          "description": "Executes a tool with the given parameters. Before using, you must call the\nsearch function to retrieve the tools you need for your task. If you do not\nknow how to call this tool, call search first.\n\nThe tool name and parameters are specified in the request body. The tool name\nmust be a string, and the parameters must be a map of strings to JSON values.\n",
+          "inputSchema": {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "title": "ExecuteParameters",
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "arguments": {
+                "type": "object",
+                "additionalProperties": true
+              }
+            },
+            "required": [
+              "name",
+              "arguments"
+            ]
+          },
+          "annotations": {
+            "destructiveHint": true,
+            "openWorldHint": true
+          }
+        }
+      ]
+    }
+    "#);
+
+    let result = mcp_client
+        .execute("tls_http_service__adder", json!({ "a": 10, "b": 20 }))
+        .await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    {
+      "content": [
+        {
+          "type": "text",
+          "text": "10 + 20 = 30"
+        }
+      ],
+      "isError": false
+    }
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_exact_matching() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["adder"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
           "description": "Adds two numbers together",
           "inputSchema": {
             "type": "object",
@@ -532,26 +678,879 @@ async fn tls_downstream_service() {
               "b"
             ]
           }
-        }
-      ]
-    }
+        },
+        "score": 0.8630463
+      }
+    ]
     "#);
 
-    // Test calling the tool
-    let result = mcp_client
-        .call_tool("tls_http_service__adder", json!({ "a": 10, "b": 20 }))
-        .await;
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_fuzzy_matching() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("text_service".to_string());
+    test_service.add_tool(TextProcessorTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["processer"]).await;
 
     insta::assert_json_snapshot!(result, @r#"
-    {
-      "content": [
-        {
-          "type": "text",
-          "text": "10 + 20 = 30"
-        }
-      ],
-      "isError": false
-    }
+    [
+      {
+        "tool": {
+          "name": "text_service__text_processor",
+          "description": "Processes text with various string manipulation operations like case conversion and reversal",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Input text to process"
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "uppercase",
+                  "lowercase",
+                  "reverse",
+                  "word_count"
+                ],
+                "description": "Action to perform on the text"
+              }
+            },
+            "required": [
+              "text",
+              "action"
+            ]
+          },
+          "annotations": {
+            "title": "Text Processor"
+          }
+        },
+        "score": 0.6
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_multiple_keywords() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["add", "numbers"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
+          "description": "Adds two numbers together",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "number",
+                "description": "First number to add"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number to add"
+              }
+            },
+            "required": [
+              "a",
+              "b"
+            ]
+          }
+        },
+        "score": 0.6
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_two() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+    test_service.add_tool(FailingTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["adder", "failing"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
+          "description": "Adds two numbers together",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "number",
+                "description": "First number to add"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number to add"
+              }
+            },
+            "required": [
+              "a",
+              "b"
+            ]
+          }
+        },
+        "score": 2.4077742
+      },
+      {
+        "tool": {
+          "name": "math_service__failing_tool",
+          "description": "A tool that always fails for testing error handling",
+          "inputSchema": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "score": 1.8299086
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_case_insensitive() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["ADDER"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
+          "description": "Adds two numbers together",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "number",
+                "description": "First number to add"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number to add"
+              }
+            },
+            "required": [
+              "a",
+              "b"
+            ]
+          }
+        },
+        "score": 0.8630463
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_by_description() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["together"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
+          "description": "Adds two numbers together",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "number",
+                "description": "First number to add"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number to add"
+              }
+            },
+            "required": [
+              "a",
+              "b"
+            ]
+          }
+        },
+        "score": 0.6
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_by_server_name() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["math"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
+          "description": "Adds two numbers together",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "number",
+                "description": "First number to add"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number to add"
+              }
+            },
+            "required": [
+              "a",
+              "b"
+            ]
+          }
+        },
+        "score": 0.2301457
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_no_results() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["nonexistent"]).await;
+
+    insta::assert_json_snapshot!(result, @"[]");
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_multiple_tools_ranking() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut math_service = TestService::streamable_http("math_service".to_string());
+    math_service.add_tool(AdderTool).await;
+
+    let mut error_service = TestService::streamable_http("error_service".to_string());
+    error_service.add_tool(FailingTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(math_service).await;
+    builder.spawn_service(error_service).await;
+
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["tool"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "error_service__failing_tool",
+          "description": "A tool that always fails for testing error handling",
+          "inputSchema": {
+            "type": "object",
+            "properties": {}
+          }
+        },
+        "score": 1.8299086
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_parameter_fields() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["First"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
+          "description": "Adds two numbers together",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "number",
+                "description": "First number to add"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number to add"
+              }
+            },
+            "required": [
+              "a",
+              "b"
+            ]
+          }
+        },
+        "score": 0.4
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_empty_query() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&[]).await;
+
+    insta::assert_json_snapshot!(result, @"[]");
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_whitespace_handling() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["  add  ", "numbers  "]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
+          "description": "Adds two numbers together",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "number",
+                "description": "First number to add"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number to add"
+              }
+            },
+            "required": [
+              "a",
+              "b"
+            ]
+          }
+        },
+        "score": 0.6
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_tool_annotations() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(CalculatorTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["Scientific"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__calculator",
+          "description": "Performs basic mathematical calculations including addition, subtraction, multiplication and division",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "add",
+                  "subtract",
+                  "multiply",
+                  "divide"
+                ],
+                "description": "Mathematical operation to perform"
+              },
+              "x": {
+                "type": "number",
+                "description": "First operand"
+              },
+              "y": {
+                "type": "number",
+                "description": "Second operand"
+              }
+            },
+            "required": [
+              "operation",
+              "x",
+              "y"
+            ]
+          },
+          "annotations": {
+            "title": "Scientific Calculator"
+          }
+        },
+        "score": 0.57536423
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_relevance_scoring_with_different_tools() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut math_service = TestService::streamable_http("math_service".to_string());
+    math_service.add_tool(CalculatorTool).await;
+    math_service.add_tool(AdderTool).await;
+
+    let mut text_service = TestService::streamable_http("text_service".to_string());
+    text_service.add_tool(TextProcessorTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(math_service).await;
+    builder.spawn_service(text_service).await;
+
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["text"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "text_service__text_processor",
+          "description": "Processes text with various string manipulation operations like case conversion and reversal",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Input text to process"
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "uppercase",
+                  "lowercase",
+                  "reverse",
+                  "word_count"
+                ],
+                "description": "Action to perform on the text"
+              }
+            },
+            "required": [
+              "text",
+              "action"
+            ]
+          },
+          "annotations": {
+            "title": "Text Processor"
+          }
+        },
+        "score": 2.4428196
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_partial_word_matching() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("text_service".to_string());
+    test_service.add_tool(TextProcessorTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["process"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "text_service__text_processor",
+          "description": "Processes text with various string manipulation operations like case conversion and reversal",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "text": {
+                "type": "string",
+                "description": "Input text to process"
+              },
+              "action": {
+                "type": "string",
+                "enum": [
+                  "uppercase",
+                  "lowercase",
+                  "reverse",
+                  "word_count"
+                ],
+                "description": "Action to perform on the text"
+              }
+            },
+            "required": [
+              "text",
+              "action"
+            ]
+          },
+          "annotations": {
+            "title": "Text Processor"
+          }
+        },
+        "score": 0.4
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_compound_words() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("file_service".to_string());
+    test_service.add_tool(FileSystemTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["filesystem"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "file_service__filesystem",
+          "description": "Manages files and directories with operations like listing, creating, and deleting",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "File or directory path"
+              },
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "list",
+                  "create",
+                  "delete",
+                  "exists"
+                ],
+                "description": "Filesystem operation to perform"
+              }
+            },
+            "required": [
+              "path",
+              "operation"
+            ]
+          },
+          "annotations": {
+            "title": "File System Manager"
+          }
+        },
+        "score": 0.8630463
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_enum_values() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(CalculatorTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+    let result = mcp_client.search(&["multiply"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__calculator",
+          "description": "Performs basic mathematical calculations including addition, subtraction, multiplication and division",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "operation": {
+                "type": "string",
+                "enum": [
+                  "add",
+                  "subtract",
+                  "multiply",
+                  "divide"
+                ],
+                "description": "Mathematical operation to perform"
+              },
+              "x": {
+                "type": "number",
+                "description": "First operand"
+              },
+              "y": {
+                "type": "number",
+                "description": "Second operand"
+              }
+            },
+            "required": [
+              "operation",
+              "x",
+              "y"
+            ]
+          },
+          "annotations": {
+            "title": "Scientific Calculator"
+          }
+        },
+        "score": 0.4
+      }
+    ]
+    "#);
+
+    mcp_client.disconnect().await;
+}
+
+#[tokio::test]
+async fn search_deduplication_test() {
+    let config = indoc! {r#"
+        [mcp]
+        enabled = true
+    "#};
+
+    let mut test_service = TestService::streamable_http("math_service".to_string());
+    test_service.add_tool(AdderTool).await;
+
+    let mut builder = TestServer::builder();
+    builder.spawn_service(test_service).await;
+    let server = builder.build(config).await;
+
+    let mcp_client = server.mcp_client("/mcp").await;
+
+    let result = mcp_client.search(&["add", "numbers"]).await;
+
+    insta::assert_json_snapshot!(result, @r#"
+    [
+      {
+        "tool": {
+          "name": "math_service__adder",
+          "description": "Adds two numbers together",
+          "inputSchema": {
+            "type": "object",
+            "properties": {
+              "a": {
+                "type": "number",
+                "description": "First number to add"
+              },
+              "b": {
+                "type": "number",
+                "description": "Second number to add"
+              }
+            },
+            "required": [
+              "a",
+              "b"
+            ]
+          }
+        },
+        "score": 0.6
+      }
+    ]
     "#);
 
     mcp_client.disconnect().await;

--- a/crates/integration-tests/tests/tools/mod.rs
+++ b/crates/integration-tests/tests/tools/mod.rs
@@ -104,4 +104,269 @@ impl TestTool for FailingTool {
     }
 }
 
+/// A calculator tool with various mathematical operations
+#[derive(Debug)]
+pub struct CalculatorTool;
+
+impl TestTool for CalculatorTool {
+    fn tool_definition(&self) -> Tool {
+        let mut schema = serde_json::Map::new();
+        schema.insert("type".to_string(), json!("object"));
+
+        let properties = json!({
+            "operation": {
+                "type": "string",
+                "enum": ["add", "subtract", "multiply", "divide"],
+                "description": "Mathematical operation to perform"
+            },
+            "x": {
+                "type": "number",
+                "description": "First operand"
+            },
+            "y": {
+                "type": "number",
+                "description": "Second operand"
+            }
+        });
+
+        schema.insert("properties".to_string(), json!(properties));
+        schema.insert("required".to_string(), json!(["operation", "x", "y"]));
+
+        Tool {
+            name: "calculator".into(),
+            description: Some(
+                "Performs basic mathematical calculations including addition, subtraction, multiplication and division"
+                    .into(),
+            ),
+            input_schema: std::sync::Arc::new(schema),
+            annotations: Some(rmcp::model::ToolAnnotations {
+                title: Some("Scientific Calculator".into()),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn call(
+        &self,
+        params: CallToolRequestParam,
+    ) -> Pin<Box<dyn Future<Output = Result<CallToolResult, ErrorData>> + Send + '_>> {
+        Box::pin(async move {
+            let args = params.arguments.ok_or_else(|| ErrorData {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "Missing arguments".into(),
+                data: None,
+            })?;
+
+            let operation = args
+                .get("operation")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ErrorData {
+                    code: rmcp::model::ErrorCode(-32602),
+                    message: "Missing or invalid parameter 'operation'".into(),
+                    data: None,
+                })?;
+
+            let x = args.get("x").and_then(|v| v.as_f64()).ok_or_else(|| ErrorData {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "Missing or invalid parameter 'x'".into(),
+                data: None,
+            })?;
+
+            let y = args.get("y").and_then(|v| v.as_f64()).ok_or_else(|| ErrorData {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "Missing or invalid parameter 'y'".into(),
+                data: None,
+            })?;
+
+            let result = match operation {
+                "add" => x + y,
+                "subtract" => x - y,
+                "multiply" => x * y,
+                "divide" => {
+                    if y == 0.0 {
+                        return Err(ErrorData {
+                            code: rmcp::model::ErrorCode(-32000),
+                            message: "Division by zero".into(),
+                            data: None,
+                        });
+                    }
+                    x / y
+                }
+                _ => {
+                    return Err(ErrorData {
+                        code: rmcp::model::ErrorCode(-32602),
+                        message: "Invalid operation".into(),
+                        data: None,
+                    });
+                }
+            };
+
+            let text = format!("{x} {operation} {y} = {result}");
+            Ok(CallToolResult::success(vec![Content::text(text)]))
+        })
+    }
+}
+
+/// A text processing tool
+#[derive(Debug)]
+pub struct TextProcessorTool;
+
+impl TestTool for TextProcessorTool {
+    fn tool_definition(&self) -> Tool {
+        let mut schema = serde_json::Map::new();
+        schema.insert("type".to_string(), json!("object"));
+
+        let properties = json!({
+            "text": {
+                "type": "string",
+                "description": "Input text to process"
+            },
+            "action": {
+                "type": "string",
+                "enum": ["uppercase", "lowercase", "reverse", "word_count"],
+                "description": "Action to perform on the text"
+            }
+        });
+
+        schema.insert("properties".to_string(), json!(properties));
+        schema.insert("required".to_string(), json!(["text", "action"]));
+
+        Tool {
+            name: "text_processor".into(),
+            description: Some(
+                "Processes text with various string manipulation operations like case conversion and reversal".into(),
+            ),
+            input_schema: std::sync::Arc::new(schema),
+            annotations: Some(rmcp::model::ToolAnnotations {
+                title: Some("Text Processor".into()),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn call(
+        &self,
+        params: CallToolRequestParam,
+    ) -> Pin<Box<dyn Future<Output = Result<CallToolResult, ErrorData>> + Send + '_>> {
+        Box::pin(async move {
+            let args = params.arguments.ok_or_else(|| ErrorData {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "Missing arguments".into(),
+                data: None,
+            })?;
+
+            let text = args.get("text").and_then(|v| v.as_str()).ok_or_else(|| ErrorData {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "Missing or invalid parameter 'text'".into(),
+                data: None,
+            })?;
+
+            let action = args.get("action").and_then(|v| v.as_str()).ok_or_else(|| ErrorData {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "Missing or invalid parameter 'action'".into(),
+                data: None,
+            })?;
+
+            let result = match action {
+                "uppercase" => text.to_uppercase(),
+                "lowercase" => text.to_lowercase(),
+                "reverse" => text.chars().rev().collect(),
+                "word_count" => text.split_whitespace().count().to_string(),
+                _ => {
+                    return Err(ErrorData {
+                        code: rmcp::model::ErrorCode(-32602),
+                        message: "Invalid action".into(),
+                        data: None,
+                    });
+                }
+            };
+
+            Ok(CallToolResult::success(vec![Content::text(result)]))
+        })
+    }
+}
+
+/// A file system tool for testing filesystem operations
+#[derive(Debug)]
+pub struct FileSystemTool;
+
+impl TestTool for FileSystemTool {
+    fn tool_definition(&self) -> Tool {
+        let mut schema = serde_json::Map::new();
+        schema.insert("type".to_string(), json!("object"));
+
+        let properties = json!({
+            "path": {
+                "type": "string",
+                "description": "File or directory path"
+            },
+            "operation": {
+                "type": "string",
+                "enum": ["list", "create", "delete", "exists"],
+                "description": "Filesystem operation to perform"
+            }
+        });
+
+        schema.insert("properties".to_string(), json!(properties));
+        schema.insert("required".to_string(), json!(["path", "operation"]));
+
+        Tool {
+            name: "filesystem".into(),
+            description: Some(
+                "Manages files and directories with operations like listing, creating, and deleting".into(),
+            ),
+            input_schema: std::sync::Arc::new(schema),
+            annotations: Some(rmcp::model::ToolAnnotations {
+                title: Some("File System Manager".into()),
+                ..Default::default()
+            }),
+        }
+    }
+
+    fn call(
+        &self,
+        params: CallToolRequestParam,
+    ) -> Pin<Box<dyn Future<Output = Result<CallToolResult, ErrorData>> + Send + '_>> {
+        Box::pin(async move {
+            let args = params.arguments.ok_or_else(|| ErrorData {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "Missing arguments".into(),
+                data: None,
+            })?;
+
+            let path = args.get("path").and_then(|v| v.as_str()).ok_or_else(|| ErrorData {
+                code: rmcp::model::ErrorCode(-32602),
+                message: "Missing or invalid parameter 'path'".into(),
+                data: None,
+            })?;
+
+            let operation = args
+                .get("operation")
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| ErrorData {
+                    code: rmcp::model::ErrorCode(-32602),
+                    message: "Missing or invalid parameter 'operation'".into(),
+                    data: None,
+                })?;
+
+            // Mock implementation for testing
+            let result = match operation {
+                "list" => format!("Contents of {path}: file1.txt, file2.txt, directory1/"),
+                "create" => format!("Created: {path}"),
+                "delete" => format!("Deleted: {path}"),
+                "exists" => format!("Path {path} exists: true"),
+                _ => {
+                    return Err(ErrorData {
+                        code: rmcp::model::ErrorCode(-32602),
+                        message: "Invalid operation".into(),
+                        data: None,
+                    });
+                }
+            };
+
+            Ok(CallToolResult::success(vec![Content::text(result)]))
+        })
+    }
+}
+
 // SSE Service Tests

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -11,6 +11,11 @@ repository.workspace = true
 anyhow = { workspace = true, features = ["backtrace"] }
 axum.workspace = true
 config.workspace = true
+convert_case.workspace = true
+futures-util.workspace = true
+http.workspace = true
+indoc.workspace = true
+itertools.workspace = true
 log = { workspace = true, features = ["kv"] }
 reqwest.workspace = true
 rmcp = { workspace = true, features = [
@@ -23,6 +28,9 @@ rmcp = { workspace = true, features = [
     "transport-io",
     "client-side-sse",
 ] }
+schemars.workspace = true
+serde = { workspace = true, features = ["derive"] }
+tantivy.workspace = true
 
 [lints]
 workspace = true

--- a/crates/mcp/src/downstream/ids.rs
+++ b/crates/mcp/src/downstream/ids.rs
@@ -1,0 +1,40 @@
+use std::ops::Index;
+
+use rmcp::model::Tool;
+
+use super::Downstream;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, serde::Serialize)]
+pub struct ToolId(u64);
+
+impl From<usize> for ToolId {
+    fn from(id: usize) -> Self {
+        ToolId(id as u64)
+    }
+}
+
+impl From<ToolId> for usize {
+    fn from(id: ToolId) -> Self {
+        id.0 as usize
+    }
+}
+
+impl From<u64> for ToolId {
+    fn from(id: u64) -> Self {
+        ToolId(id)
+    }
+}
+
+impl From<ToolId> for u64 {
+    fn from(id: ToolId) -> Self {
+        id.0
+    }
+}
+
+impl Index<ToolId> for Downstream {
+    type Output = Tool;
+
+    fn index(&self, index: ToolId) -> &Self::Output {
+        &self.tools[index.0 as usize]
+    }
+}

--- a/crates/mcp/src/server/index.rs
+++ b/crates/mcp/src/server/index.rs
@@ -1,0 +1,349 @@
+use std::collections::HashSet;
+
+use convert_case::Boundary;
+use rmcp::{
+    model::Tool,
+    serde_json::{self, Map, Value},
+};
+use tantivy::{
+    Index, IndexReader, IndexWriter, TantivyDocument, Term,
+    collector::TopDocs,
+    doc,
+    query::{BooleanQuery, BoostQuery, DisjunctionMaxQuery, FuzzyTermQuery, Occur, Query, TermQuery},
+    schema::{Field, IndexRecordOption, STORED, Schema, TEXT, Value as _},
+};
+
+use crate::downstream::ToolId;
+
+const HEAP_SIZE: usize = 50 * 1024 * 1024; // 50MB
+const TOP_DOCS_LIMIT: usize = 10; // Only fetch what we need
+const MAX_RESULTS: usize = 10;
+
+/// A search index for tools that provides efficient full-text search capabilities.
+///
+/// The index stores tools with their metadata and provides fuzzy search functionality
+/// across tool names, descriptions, and input parameters.
+pub struct ToolIndex {
+    reader: IndexReader,
+    writer: IndexWriter,
+    fields: IndexFields,
+}
+
+/// Internal field definitions for the search index.
+struct IndexFields {
+    /// Human-readable title for the tool
+    tool_title: Field,
+    /// Original tool name (without server prefix)
+    tool_name: Field,
+    /// Server name (without tool suffix)
+    server_name: Field,
+    /// Tool description
+    description: Field,
+    /// JSON string of input parameters
+    input_params: Field,
+    /// Tokenized searchable content
+    search_tokens: Field,
+    /// Tool ID
+    id: Field,
+}
+
+/// A search result containing a tool and its relevance score.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SearchResult {
+    /// The tool that matched the search query
+    pub tool_id: ToolId,
+    /// The relevance score for this result (higher is more relevant)
+    pub score: f32,
+}
+
+impl ToolIndex {
+    /// Creates a new empty tool index.
+    pub fn new() -> anyhow::Result<Self> {
+        let mut builder = Schema::builder();
+
+        let fields = IndexFields {
+            tool_title: builder.add_text_field("tool_title", TEXT | STORED),
+            tool_name: builder.add_text_field("tool_name", TEXT | STORED),
+            server_name: builder.add_text_field("server_name", TEXT | STORED),
+            description: builder.add_text_field("description", TEXT | STORED),
+            input_params: builder.add_text_field("input_params", TEXT | STORED),
+            search_tokens: builder.add_text_field("search_tokens", TEXT | STORED),
+            id: builder.add_text_field("id", STORED),
+        };
+
+        let schema = builder.build();
+        let index = Index::create_in_ram(schema);
+        let reader = index.reader()?;
+        let writer = index.writer(HEAP_SIZE)?;
+
+        Ok(Self { reader, writer, fields })
+    }
+
+    /// Adds a tool to the index.
+    ///
+    /// The tool name must be in the format "server_name__tool_name" where "__" separates
+    /// the server name from the tool name.
+    pub fn add_tool(&mut self, tool: &Tool, id: ToolId) -> anyhow::Result<()> {
+        let Some((server_name, tool_name)) = tool.name.split_once("__") else {
+            return Err(anyhow::anyhow!("Invalid tool name format: missing server name"));
+        };
+
+        let mut doc = doc!(
+            self.fields.tool_name => tool_name,
+            self.fields.server_name => server_name,
+        );
+
+        if let Some(ref description) = tool.description {
+            doc.add_text(self.fields.description, description);
+        }
+
+        if !tool.input_schema.is_empty() {
+            let input_schema = serde_json::to_string(&tool.input_schema)?;
+            doc.add_text(self.fields.input_params, &input_schema);
+        }
+
+        if let Some(ref annotations) = tool.annotations {
+            if let Some(ref title) = annotations.title {
+                doc.add_text(self.fields.tool_title, title);
+            }
+        }
+
+        let search_tokens = self.generate_search_tokens(tool)?;
+        doc.add_text(self.fields.search_tokens, &search_tokens);
+
+        doc.add_u64(self.fields.id, id.into());
+
+        self.writer.add_document(doc)?;
+
+        Ok(())
+    }
+
+    /// Commits all pending changes to the index and reloads the reader.
+    ///
+    /// This must be called after adding tools to make them available for searching.
+    pub fn commit(&mut self) -> anyhow::Result<()> {
+        self.writer.commit()?;
+        self.reader.reload()?;
+
+        Ok(())
+    }
+
+    /// Searches for tools matching the given keywords.
+    ///
+    /// The search uses a combination of exact matching and fuzzy matching across
+    /// different fields, with relevance scoring to rank results.
+    ///
+    /// # Arguments
+    ///
+    /// * `keywords` - An iterator of search terms
+    pub fn search<'a, I>(&self, keywords: I) -> anyhow::Result<Vec<SearchResult>>
+    where
+        I: IntoIterator<Item = &'a str>,
+        I::IntoIter: ExactSizeIterator,
+    {
+        let searcher = self.reader.searcher();
+        let keywords = keywords.into_iter();
+
+        if keywords.len() == 0 {
+            return Ok(Vec::new());
+        }
+
+        let query = self.build_combined_search_query(keywords)?;
+
+        // Use exact limit instead of 100
+        let top_docs = searcher.search(&query, &TopDocs::with_limit(TOP_DOCS_LIMIT))?;
+
+        let mut results = Vec::with_capacity(TOP_DOCS_LIMIT);
+        let mut seen_tools = HashSet::new();
+
+        for (score, doc_address) in top_docs {
+            let doc = searcher.doc(doc_address)?;
+            if let Ok(search_result) = self.doc_to_search_result(&doc, score) {
+                // Deduplicate by tool name
+                if seen_tools.insert(search_result.tool_id) {
+                    results.push(search_result);
+
+                    if results.len() >= MAX_RESULTS {
+                        break;
+                    }
+                }
+            }
+        }
+
+        Ok(results)
+    }
+
+    /// Converts a Tantivy document to a search result.
+    fn doc_to_search_result(&self, doc: &TantivyDocument, score: f32) -> anyhow::Result<SearchResult> {
+        let tool_id = doc
+            .get_first(self.fields.id)
+            .and_then(|v| v.as_u64())
+            .ok_or(anyhow::anyhow!("field is not u64"))?
+            .into();
+
+        Ok(SearchResult { tool_id, score })
+    }
+
+    /// Generates searchable tokens from a tool's metadata.
+    fn generate_search_tokens(&self, tool: &Tool) -> anyhow::Result<String> {
+        let Some((server_name, tool_name)) = tool.name.split_once("__") else {
+            return Err(anyhow::anyhow!("Invalid tool name format: missing server name"));
+        };
+
+        let mut buffer = String::with_capacity(256);
+
+        for (i, token) in tokenize_name(server_name).into_iter().enumerate() {
+            if i > 0 {
+                buffer.push(' ');
+            }
+            buffer.push_str(&token);
+        }
+
+        for token in tokenize_name(tool_name) {
+            if !buffer.is_empty() {
+                buffer.push(' ');
+            }
+            buffer.push_str(&token);
+        }
+
+        if let Some(ref desc) = tool.description {
+            if !buffer.is_empty() {
+                buffer.push(' ');
+            }
+            buffer.push_str(desc);
+        }
+
+        for token in tokenize_map(&tool.input_schema) {
+            if !buffer.is_empty() {
+                buffer.push(' ');
+            }
+            buffer.push_str(&token);
+        }
+
+        Ok(buffer)
+    }
+
+    /// Builds a combined search query from keywords.
+    fn build_combined_search_query<'a>(
+        &self,
+        keywords: impl ExactSizeIterator<Item = &'a str>,
+    ) -> anyhow::Result<Box<dyn Query>> {
+        let mut main_queries: Vec<(Occur, Box<dyn Query>)> = Vec::new();
+
+        for keyword in keywords {
+            let terms = parse_query_terms(keyword);
+            let mut keyword_queries: Vec<Box<dyn Query>> = Vec::new();
+
+            for term in terms {
+                // Only use fuzzy for terms longer than 4 chars and when it makes sense
+                let use_fuzzy = term.len() > 4 && !term.chars().all(|c| c.is_ascii_digit());
+
+                let mut term_queries = Vec::new();
+
+                // Exact matches in important fields (higher scores)
+                self.add_exact_term_queries(&term, &mut term_queries);
+
+                // Fuzzy matches only when beneficial
+                if use_fuzzy {
+                    self.add_fuzzy_term_queries(&term, &mut term_queries);
+                }
+
+                if !term_queries.is_empty() {
+                    keyword_queries.push(Box::new(DisjunctionMaxQuery::new(term_queries)));
+                }
+            }
+
+            if !keyword_queries.is_empty() {
+                main_queries.push((Occur::Should, Box::new(DisjunctionMaxQuery::new(keyword_queries))));
+            }
+        }
+
+        Ok(Box::new(BooleanQuery::new(main_queries)))
+    }
+
+    /// Adds exact term queries for important fields.
+    fn add_exact_term_queries(&self, term: &str, queries: &mut Vec<Box<dyn Query>>) {
+        // Focus on most relevant fields with appropriate scoring
+        let important_fields = [
+            (self.fields.tool_name, 3.0),
+            (self.fields.tool_title, 2.0),
+            (self.fields.description, 1.2),
+            (self.fields.server_name, 0.8),
+        ];
+
+        for (field, boost) in important_fields {
+            let term_obj = Term::from_field_text(field, term);
+            let query = Box::new(BoostQuery::new(
+                Box::new(TermQuery::new(term_obj, IndexRecordOption::Basic)),
+                boost,
+            ));
+            queries.push(query);
+        }
+    }
+
+    /// Adds fuzzy term queries for less critical fields.
+    fn add_fuzzy_term_queries(&self, term: &str, queries: &mut Vec<Box<dyn Query>>) {
+        // Add fuzzy queries for less critical fields
+        let fuzzy_fields = [
+            (self.fields.description, 0.6),
+            (self.fields.input_params, 0.4),
+            (self.fields.search_tokens, 0.3),
+        ];
+
+        for (field, boost) in fuzzy_fields {
+            let term_obj = Term::from_field_text(field, term);
+            let fuzzy_query = Box::new(FuzzyTermQuery::new(term_obj, 1, true));
+            let boosted_query = Box::new(BoostQuery::new(fuzzy_query, boost));
+            queries.push(boosted_query);
+        }
+    }
+}
+
+/// Extracts searchable tokens from a JSON object map.
+///
+/// Recursively traverses the map and tokenizes all string keys.
+fn tokenize_map(map: &Map<String, Value>) -> Vec<String> {
+    let mut tokens = Vec::new();
+
+    for (key, value) in map.iter() {
+        tokens.extend(tokenize_name(key));
+
+        if let Value::Object(map) = value {
+            tokens.extend(tokenize_map(map))
+        }
+    }
+
+    tokens
+}
+
+/// Tokenizes a name string into searchable terms.
+///
+/// Splits the name on word boundaries and converts to lowercase,
+/// filtering out single characters and empty strings.
+fn tokenize_name(name: &str) -> Vec<String> {
+    convert_case::split(&name, &Boundary::defaults())
+        .into_iter()
+        .map(|s| s.trim().to_lowercase())
+        .filter(|s| !s.is_empty() && s.len() > 1) // Filter out single chars
+        .collect()
+}
+
+/// Parses a query string into individual search terms.
+///
+/// Splits the query on whitespace and then further tokenizes each term
+/// using word boundaries, filtering out short terms.
+fn parse_query_terms(query: &str) -> Vec<String> {
+    // Pre-allocate with estimated capacity
+    let mut terms = Vec::with_capacity(query.split_whitespace().count() * 2);
+
+    for term in query.split_whitespace() {
+        let converted = convert_case::split(&term, &Boundary::defaults())
+            .into_iter()
+            .map(|s| s.trim().to_lowercase())
+            .filter(|s| !s.is_empty() && s.len() > 1);
+
+        terms.extend(converted);
+    }
+
+    terms
+}

--- a/crates/mcp/src/server/tool.rs
+++ b/crates/mcp/src/server/tool.rs
@@ -1,0 +1,115 @@
+mod execute;
+mod search;
+
+pub use execute::ExecuteTool;
+pub use search::SearchTool;
+
+use std::borrow::Cow;
+
+use axum::http::request::Parts;
+use futures_util::future::BoxFuture;
+use rmcp::{
+    ErrorData, RoleServer,
+    model::{CallToolResult, Content, ErrorCode, JsonObject, ToolAnnotations},
+    serde_json::{self, Value},
+    service::RequestContext,
+};
+use schemars::schema_for;
+use serde::de::DeserializeOwned;
+
+pub(crate) trait Tool: Send + Sync + 'static {
+    type Parameters: DeserializeOwned + schemars::JsonSchema;
+
+    fn name() -> &'static str;
+    fn description(&self) -> Cow<'_, str>;
+    fn annotations(&self) -> ToolAnnotations;
+
+    fn call(
+        &self,
+        parts: Parts,
+        parameters: Self::Parameters,
+    ) -> impl Future<Output = anyhow::Result<CallToolResult>> + Send;
+}
+
+pub(crate) trait RmcpTool: Send + Sync + 'static {
+    fn name(&self) -> &str;
+    fn to_tool(&self) -> rmcp::model::Tool;
+
+    fn call(
+        &self,
+        ctx: RequestContext<RoleServer>,
+        parameters: Option<JsonObject>,
+    ) -> BoxFuture<'_, Result<CallToolResult, ErrorData>>;
+}
+
+impl<T: Tool> RmcpTool for T {
+    fn name(&self) -> &str {
+        T::name()
+    }
+
+    fn to_tool(&self) -> rmcp::model::Tool {
+        let Value::Object(schema) = serde_json::to_value(schema_for!(<T as Tool>::Parameters)).unwrap() else {
+            unreachable!()
+        };
+
+        rmcp::model::Tool::new(self.name().to_string(), self.description().into_owned(), schema)
+            .annotate(self.annotations())
+    }
+
+    fn call(
+        &self,
+        mut ctx: RequestContext<RoleServer>,
+        parameters: Option<JsonObject>,
+    ) -> BoxFuture<'_, Result<CallToolResult, ErrorData>> {
+        let parts = ctx
+            .extensions
+            .remove::<Parts>()
+            .unwrap_or_else(|| http::Request::builder().body(Vec::<u8>::new()).unwrap().into_parts().0);
+
+        Box::pin(async move {
+            let parameters: T::Parameters = serde_json::from_value(Value::Object(parameters.unwrap_or_default()))
+                .map_err(|err| ErrorData::new(ErrorCode::INVALID_PARAMS, err.to_string(), None))?;
+
+            match Tool::call(self, parts, parameters).await {
+                Ok(data) => Ok(data),
+                Err(err) => {
+                    // Try to downcast the anyhow::Error back to ErrorData
+                    if let Some(error_data) = err.downcast_ref::<ErrorData>() {
+                        Err(error_data.clone())
+                    } else {
+                        Err(ErrorData::new(ErrorCode::INTERNAL_ERROR, err.to_string(), None))
+                    }
+                }
+            }
+        })
+    }
+}
+
+struct SdlAndErrors {
+    sdl: String,
+    errors: Vec<String>,
+}
+
+impl From<SdlAndErrors> for CallToolResult {
+    fn from(SdlAndErrors { sdl, errors }: SdlAndErrors) -> Self {
+        let mut content = Vec::new();
+
+        if !sdl.is_empty() {
+            content.push(Content::text(sdl));
+        }
+
+        if !errors.is_empty() {
+            content.push(Content::json(ErrorList { errors }).unwrap());
+        }
+
+        CallToolResult {
+            content,
+            is_error: None,
+        }
+    }
+}
+
+#[derive(serde::Serialize)]
+struct ErrorList<T> {
+    errors: Vec<T>,
+}

--- a/crates/mcp/src/server/tool/execute.rs
+++ b/crates/mcp/src/server/tool/execute.rs
@@ -1,0 +1,105 @@
+use std::{borrow::Cow, sync::Arc};
+
+use http::request::Parts;
+use itertools::Itertools;
+use rmcp::{
+    model::{CallToolRequestParam, CallToolResult, ErrorCode, ToolAnnotations},
+    serde_json::{Map, Value},
+};
+use schemars::{JsonSchema, Schema, SchemaGenerator};
+
+use crate::{downstream::Downstream, server::index::ToolIndex};
+
+use super::Tool;
+
+pub struct ExecuteTool {
+    downstream: Arc<Downstream>,
+    index: Arc<ToolIndex>,
+}
+
+impl ExecuteTool {
+    pub fn new(downstream: Arc<Downstream>, index: Arc<ToolIndex>) -> Self {
+        Self { downstream, index }
+    }
+}
+
+#[derive(serde::Deserialize, serde::Serialize)]
+pub struct ExecuteParameters {
+    pub name: String,
+    pub arguments: Option<Map<String, Value>>,
+}
+
+impl JsonSchema for ExecuteParameters {
+    fn schema_name() -> Cow<'static, str> {
+        "ExecuteParameters".into()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        schemars::json_schema!({
+            "type": "object",
+            "properties": {
+                "name": generator.subschema_for::<String>(),
+                // This is for Cursor, who does not like optional arguments, but will
+                // happily send us an empty object.
+                "arguments": generator.subschema_for::<Map<String, Value>>()
+            },
+            "required": ["name", "arguments"]
+        })
+    }
+}
+
+impl Tool for ExecuteTool {
+    type Parameters = ExecuteParameters;
+
+    fn name() -> &'static str {
+        "execute"
+    }
+
+    fn description(&self) -> Cow<'_, str> {
+        let description = indoc::indoc! {r#"
+            Executes a tool with the given parameters. Before using, you must call the
+            search function to retrieve the tools you need for your task. If you do not
+            know how to call this tool, call search first.
+
+            The tool name and parameters are specified in the request body. The tool name
+            must be a string, and the parameters must be a map of strings to JSON values.
+        "#};
+
+        Cow::Borrowed(description)
+    }
+
+    fn annotations(&self) -> ToolAnnotations {
+        ToolAnnotations::new().destructive(true).open_world(true)
+    }
+
+    async fn call(&self, _: Parts, parameters: Self::Parameters) -> anyhow::Result<CallToolResult> {
+        let ExecuteParameters { name, arguments } = parameters;
+
+        let param = CallToolRequestParam {
+            name: name.clone().into(),
+            arguments,
+        };
+
+        match self.downstream.execute(param).await {
+            Ok(result) => Ok(result),
+            Err(mut error_data) => {
+                if error_data.code == ErrorCode::INVALID_PARAMS && error_data.message.contains("Unknown tool") {
+                    let did_you_mean = self.index.search([name.as_str()])?;
+
+                    if !did_you_mean.is_empty() {
+                        let did_you_mean = did_you_mean
+                            .into_iter()
+                            .map(|s| &self.downstream[s.tool_id].name)
+                            .join(", ");
+
+                        error_data.message = format!("{}. Did you mean: {did_you_mean}", error_data.message).into();
+                    }
+
+                    Err(anyhow::Error::new(error_data))
+                } else {
+                    Err(anyhow::Error::new(error_data))
+                }
+            }
+        }
+    }
+}

--- a/crates/mcp/src/server/tool/search.rs
+++ b/crates/mcp/src/server/tool/search.rs
@@ -1,0 +1,80 @@
+use std::{borrow::Cow, sync::Arc};
+
+use http::request::Parts;
+use indoc::indoc;
+use rmcp::model::{CallToolResult, Content, ToolAnnotations};
+use schemars::JsonSchema;
+use serde::Deserialize;
+
+use crate::{downstream::Downstream, server::index::ToolIndex};
+
+use super::Tool;
+
+#[derive(Deserialize, JsonSchema)]
+pub struct SearchParameters {
+    keywords: Vec<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct SearchResult<'a> {
+    /// The tool that matched the search query
+    pub tool: &'a rmcp::model::Tool,
+    /// The relevance score for this result (higher is more relevant)
+    pub score: f32,
+}
+
+pub struct SearchTool {
+    downstream: Arc<Downstream>,
+    index: Arc<ToolIndex>,
+}
+
+impl SearchTool {
+    pub fn new(downstream: Arc<Downstream>, index: Arc<ToolIndex>) -> Self {
+        Self { downstream, index }
+    }
+}
+
+impl Tool for SearchTool {
+    type Parameters = SearchParameters;
+
+    fn name() -> &'static str {
+        "search"
+    }
+
+    fn description(&self) -> Cow<'_, str> {
+        let description = indoc! {r#"
+            Search for relevant tools. A list of matching tools with their
+            score is returned with a map of input fields and their types.
+
+            Using this information, you can call the execute tool with the
+            name of the tool you want to execute, and defining the input
+            parameters.
+        "#};
+
+        Cow::Borrowed(description)
+    }
+
+    fn annotations(&self) -> ToolAnnotations {
+        ToolAnnotations::new().read_only(true)
+    }
+
+    async fn call(&self, _: Parts, parameters: Self::Parameters) -> anyhow::Result<CallToolResult> {
+        let SearchParameters { keywords } = parameters;
+
+        let mut content = Vec::new();
+
+        for result in self.index.search(keywords.iter().map(|s| s.as_str()))? {
+            let result = Content::json(SearchResult {
+                tool: &self.downstream[result.tool_id],
+                score: result.score,
+            })?;
+
+            content.push(result);
+        }
+
+        Ok(CallToolResult {
+            content,
+            is_error: None,
+        })
+    }
+}


### PR DESCRIPTION
After our call this week, I decided to not do the LRU just yet. Let's wait and see when LLMs can actually working with a dynamic toolset. This implements the search and execute functionality.

The list of tools, or the tools in search, are in stringified text form (escaped JSON). Now this looks weird, but it is the right way to return the data in the March standard:

https://blogs.cisco.com/developer/whats-new-in-mcp-elicitation-structured-content-and-oauth-enhancements

This article also discusses the structuredContent of the June standard. rmcp does not support this yet, but when it does I will adapt our code.