### PR TITLE
fix: sigh, again try to fix the docker-main on releases

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -262,7 +262,7 @@ jobs:
           pr_number: ${{ github.event.pull_request.number }}
 
   docker-main:
-    if: github.ref == 'refs/heads/main' && github.event_name != 'workflow_call'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     needs: [check-rust-format, check-toml-format, unit-tests, integration-tests]
     runs-on: depot-ubuntu-24.04-8
     permissions:


### PR DESCRIPTION
This got triggered by the release again, and naturally it fails and stops the whole process.

We generate a docker image in the release workflow, the docker-main one is only when something gets merged to main.