### PR TITLE
feat(gb-9579): redis metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5105,7 +5105,9 @@ dependencies = [
  "governor",
  "log",
  "mini-moka",
+ "opentelemetry",
  "redis",
+ "telemetry",
  "thiserror 2.0.16",
  "tokio",
 ]

--- a/README.md
+++ b/README.md
@@ -1350,10 +1350,10 @@ All histograms also function as counters (count field tracks number of observati
 
 **MCP Operation Metrics:**
 - `mcp.tool.call.duration` (histogram)
-  - Attributes: `tool_name`, `tool_type` (builtin/downstream), `status` (success/error), `client_id`, `group`
+  - Attributes: `tool_name`, `tool_type` (builtin/downstream), `status` (success/error), `client.id`, `client.group`
   - Additional for search: `keyword_count`, `result_count`
   - Additional for execute: `server_name` (for downstream tools)
-  - Additional for errors: `error_type`:
+  - Additional for errors: `error.type`:
     - `parse_error` - Invalid JSON (-32700)
     - `invalid_request` - Not a valid request (-32600)
     - `method_not_found` - Method/tool does not exist (-32601)
@@ -1364,15 +1364,15 @@ All histograms also function as counters (count field tracks number of observati
     - `unknown` - Any other error code
 
 - `mcp.tools.list.duration` (histogram)
-  - Attributes: `method` (list_tools), `status`, `client_id`, `group`
+  - Attributes: `method` (list_tools), `status`, `client.id`, `client.group`
 
 - `mcp.prompt.request.duration` (histogram)
-  - Attributes: `method` (list_prompts/get_prompt), `status`, `client_id`, `group`
-  - Additional for errors: `error_type` (same values as above)
+  - Attributes: `method` (list_prompts/get_prompt), `status`, `client.id`, `client.group`
+  - Additional for errors: `error.type` (same values as above)
 
 - `mcp.resource.request.duration` (histogram)
-  - Attributes: `method` (list_resources/read_resource), `status`, `client_id`, `group`
-  - Additional for errors: `error_type` (same values as above)
+  - Attributes: `method` (list_resources/read_resource), `status`, `client.id`, `client.group`
+  - Additional for errors: `error.type` (same values as above)
 
 **LLM Operation Metrics:**
 - `gen_ai.client.operation.duration` (histogram)

--- a/README.md
+++ b/README.md
@@ -1413,6 +1413,24 @@ All histograms also function as counters (count field tracks number of observati
   - Cumulative total token consumption (input + output)
   - Attributes: `gen_ai.system`, `gen_ai.request.model`, `client.id`, `client.group`
 
+**Redis Storage Metrics (when rate limiting with Redis is enabled):**
+- `redis.command.duration` (histogram)
+  - Tracks Redis command execution times
+  - Attributes:
+    - `operation` - The Redis operation type:
+      - `check_and_consume` - HTTP rate limit checking
+      - `check_and_consume_tokens` - Token-based rate limit checking
+    - `status` (success/error)
+    - `tokens` (for token operations) - Number of tokens checked
+
+- `redis.pool.connections.in_use` (gauge)
+  - Current number of connections in use from the pool
+  - No additional attributes
+
+- `redis.pool.connections.available` (gauge)
+  - Current number of available connections in the pool
+  - No additional attributes
+
 ## Adding to AI Assistants
 
 ### Cursor

--- a/crates/integration-tests/tests/telemetry/metrics.rs
+++ b/crates/integration-tests/tests/telemetry/metrics.rs
@@ -1,17 +1,19 @@
 //! Tests for telemetry metrics collection
 
 use clickhouse::Row;
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 
 mod llm;
 mod mcp;
+mod redis;
 
 /// Row structure for histogram metrics in ClickHouse
-#[derive(Row, Deserialize, Debug, Clone)]
+#[derive(Row, Deserialize, Serialize, Debug, Clone)]
 #[serde(rename_all = "PascalCase")]
 pub struct HistogramMetricRow {
     pub metric_name: String,
     pub attributes: Vec<(String, String)>,
+    #[serde(alias = "Count")]
     pub count: u64,
 }
 
@@ -21,5 +23,17 @@ pub struct HistogramMetricRow {
 pub struct SumMetricRow {
     pub metric_name: String,
     pub attributes: Vec<(String, String)>,
+    pub value: f64,
+}
+
+/// Row structure for gauge metrics in ClickHouse
+#[derive(Row, Deserialize, Debug, Clone)]
+#[serde(rename_all = "PascalCase")]
+pub struct GaugeMetricRow {
+    #[allow(dead_code)]
+    pub metric_name: String,
+    #[allow(dead_code)]
+    pub attributes: Vec<(String, String)>,
+    #[allow(dead_code)]
     pub value: f64,
 }

--- a/crates/integration-tests/tests/telemetry/metrics/mcp.rs
+++ b/crates/integration-tests/tests/telemetry/metrics/mcp.rs
@@ -155,7 +155,7 @@ async fn search_tool_metrics() {
         WHERE
             MetricName = 'mcp.tool.call.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -173,7 +173,7 @@ async fn search_tool_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = first_row
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
@@ -182,7 +182,7 @@ async fn search_tool_metrics() {
     // - result_count: "1" - exactly 1 tool matches: AdderTool from test_mcp_server
     insta::assert_debug_snapshot!(attrs, @r###"
     {
-        "group": "test-group",
+        "client.group": "test-group",
         "keyword_count": "1",
         "result_count": "1",
         "status": "success",
@@ -238,7 +238,7 @@ async fn execute_tool_metrics() {
         WHERE
             MetricName = 'mcp.tool.call.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -254,14 +254,14 @@ async fn execute_tool_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = tool_histograms[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
     // Use snapshot for static fields
     insta::assert_debug_snapshot!(attrs, @r###"
     {
-        "group": "execute-test-group",
+        "client.group": "execute-test-group",
         "server_name": "test_mcp_server",
         "status": "success",
         "tool_name": "adder",
@@ -272,7 +272,7 @@ async fn execute_tool_metrics() {
     // Check dynamic field separately with assert_eq!
     let full_attrs: std::collections::BTreeMap<_, _> = tool_histograms[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -310,7 +310,7 @@ async fn list_tools_metrics() {
         WHERE
             MetricName = 'mcp.tools.list.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -325,12 +325,12 @@ async fn list_tools_metrics() {
 
     // Create a filtered version without dynamic client_id for snapshots
     let mut attrs_snapshot = tools_attrs.clone();
-    attrs_snapshot.remove("client_id");
+    attrs_snapshot.remove("client.id");
 
     // Snapshot the static attributes
     insta::assert_debug_snapshot!(attrs_snapshot, @r#"
     {
-        "group": "method-test-group",
+        "client.group": "method-test-group",
         "method": "list_tools",
         "status": "success",
     }
@@ -338,7 +338,7 @@ async fn list_tools_metrics() {
 
     // Separately verify the dynamic client_id exists
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(tools_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(tools_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -368,7 +368,7 @@ async fn list_prompts_metrics() {
         WHERE
             MetricName = 'mcp.prompt.request.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -382,14 +382,14 @@ async fn list_prompts_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
     // Use snapshot for static fields
     insta::assert_debug_snapshot!(attrs, @r###"
     {
-        "group": "prompts-group",
+        "client.group": "prompts-group",
         "method": "list_prompts",
         "status": "success",
     }
@@ -398,7 +398,7 @@ async fn list_prompts_metrics() {
     // Check dynamic field separately with assert_eq!
     let full_attrs: std::collections::BTreeMap<_, _> = metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -428,7 +428,7 @@ async fn list_resources_metrics() {
         WHERE
             MetricName = 'mcp.resource.request.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -442,14 +442,14 @@ async fn list_resources_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
     // Use snapshot for static fields
     insta::assert_debug_snapshot!(attrs, @r###"
     {
-        "group": "resources-group",
+        "client.group": "resources-group",
         "method": "list_resources",
         "status": "success",
     }
@@ -458,7 +458,7 @@ async fn list_resources_metrics() {
     // Check dynamic field separately with assert_eq!
     let full_attrs: std::collections::BTreeMap<_, _> = metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -497,7 +497,7 @@ async fn get_prompt_success_metrics() {
         WHERE
             MetricName = 'mcp.prompt.request.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -511,20 +511,20 @@ async fn get_prompt_success_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id")
+        .filter(|(k, _)| k.as_str() != "client.id")
         .cloned()
         .collect();
 
     insta::assert_debug_snapshot!(attrs, @r###"
     {
-        "group": "prompt-success-group",
+        "client.group": "prompt-success-group",
         "method": "get_prompt",
         "status": "success",
     }
     "###);
 
     let full_attrs: std::collections::BTreeMap<_, _> = metrics[0].attributes.iter().cloned().collect();
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -566,7 +566,7 @@ async fn read_resource_success_metrics() {
         WHERE
             MetricName = 'mcp.resource.request.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -580,20 +580,20 @@ async fn read_resource_success_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id")
+        .filter(|(k, _)| k.as_str() != "client.id")
         .cloned()
         .collect();
 
     insta::assert_debug_snapshot!(attrs, @r###"
     {
-        "group": "resource-success-group",
+        "client.group": "resource-success-group",
         "method": "read_resource",
         "status": "success",
     }
     "###);
 
     let full_attrs: std::collections::BTreeMap<_, _> = metrics[0].attributes.iter().cloned().collect();
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -623,7 +623,7 @@ async fn get_prompt_error_metrics() {
         WHERE
             MetricName = 'mcp.prompt.request.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -637,15 +637,15 @@ async fn get_prompt_error_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
     // Use snapshot for static fields
     insta::assert_debug_snapshot!(attrs, @r#"
     {
-        "error_type": "method_not_found",
-        "group": "error-group",
+        "client.group": "error-group",
+        "error.type": "method_not_found",
         "method": "get_prompt",
         "status": "error",
     }
@@ -654,7 +654,7 @@ async fn get_prompt_error_metrics() {
     // Check dynamic field separately with assert_eq!
     let full_attrs: std::collections::BTreeMap<_, _> = metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -684,7 +684,7 @@ async fn read_resource_error_metrics() {
         WHERE
             MetricName = 'mcp.resource.request.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
+            AND Attributes['client.id'] = '{client_id}'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -698,15 +698,15 @@ async fn read_resource_error_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
     // Use snapshot for static fields
     insta::assert_debug_snapshot!(attrs, @r#"
     {
-        "error_type": "method_not_found",
-        "group": "error-group",
+        "client.group": "error-group",
+        "error.type": "method_not_found",
         "method": "read_resource",
         "status": "error",
     }
@@ -715,7 +715,7 @@ async fn read_resource_error_metrics() {
     // Check dynamic field separately with assert_eq!
     let full_attrs: std::collections::BTreeMap<_, _> = metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -748,8 +748,8 @@ async fn execute_invalid_tool_name_metrics() {
         WHERE
             MetricName = 'mcp.tool.call.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
-            AND Attributes['error_type'] = 'method_not_found'
+            AND Attributes['client.id'] = '{client_id}'
+            AND Attributes['error.type'] = 'method_not_found'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -763,15 +763,15 @@ async fn execute_invalid_tool_name_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = error_metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
     // Use snapshot for static fields
     insta::assert_debug_snapshot!(attrs, @r#"
     {
-        "error_type": "method_not_found",
-        "group": "error-group",
+        "client.group": "error-group",
+        "error.type": "method_not_found",
         "status": "error",
         "tool_name": "invalidtoolname",
         "tool_type": "downstream",
@@ -781,7 +781,7 @@ async fn execute_invalid_tool_name_metrics() {
     // Check dynamic field separately with assert_eq!
     let full_attrs: std::collections::BTreeMap<_, _> = error_metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -816,8 +816,8 @@ async fn execute_server_not_found_metrics() {
         WHERE
             MetricName = 'mcp.tool.call.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
-            AND Attributes['error_type'] = 'method_not_found'
+            AND Attributes['client.id'] = '{client_id}'
+            AND Attributes['error.type'] = 'method_not_found'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -831,15 +831,15 @@ async fn execute_server_not_found_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = error_metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
     // Use snapshot for static fields
     insta::assert_debug_snapshot!(attrs, @r#"
     {
-        "error_type": "method_not_found",
-        "group": "error-group",
+        "client.group": "error-group",
+        "error.type": "method_not_found",
         "status": "error",
         "tool_name": "nonexistent_server__some_tool",
         "tool_type": "downstream",
@@ -849,7 +849,7 @@ async fn execute_server_not_found_metrics() {
     // Check dynamic field separately with assert_eq!
     let full_attrs: std::collections::BTreeMap<_, _> = error_metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -884,8 +884,8 @@ async fn execute_tool_not_found_metrics() {
         WHERE
             MetricName = 'mcp.tool.call.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
-            AND Attributes['error_type'] = 'method_not_found'
+            AND Attributes['client.id'] = '{client_id}'
+            AND Attributes['error.type'] = 'method_not_found'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -899,15 +899,15 @@ async fn execute_tool_not_found_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = error_metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id") // Filter out dynamic client_id
+        .filter(|(k, _)| k.as_str() != "client.id") // Filter out dynamic client.id
         .cloned()
         .collect();
 
     // Use snapshot for static fields
     insta::assert_debug_snapshot!(attrs, @r#"
     {
-        "error_type": "method_not_found",
-        "group": "error-group",
+        "client.group": "error-group",
+        "error.type": "method_not_found",
         "status": "error",
         "tool_name": "test_mcp_server__nonexistent_tool",
         "tool_type": "downstream",
@@ -917,7 +917,7 @@ async fn execute_tool_not_found_metrics() {
     // Check dynamic field separately with assert_eq!
     let full_attrs: std::collections::BTreeMap<_, _> = error_metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -955,8 +955,8 @@ async fn downstream_rate_limit_exceeded_metrics() {
         WHERE
             MetricName = 'mcp.tool.call.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
-            AND Attributes['error_type'] = 'rate_limit_exceeded'
+            AND Attributes['client.id'] = '{client_id}'
+            AND Attributes['error.type'] = 'rate_limit_exceeded'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -970,25 +970,25 @@ async fn downstream_rate_limit_exceeded_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = error_metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id")
+        .filter(|(k, _)| k.as_str() != "client.id")
         .cloned()
         .collect();
 
     // Verify the error is tracked as rate_limit_exceeded
-    insta::assert_debug_snapshot!(attrs, @r###"
+    insta::assert_debug_snapshot!(attrs, @r#"
     {
-        "error_type": "rate_limit_exceeded",
-        "group": "rate-limit-group",
+        "client.group": "rate-limit-group",
+        "error.type": "rate_limit_exceeded",
         "status": "error",
         "tool_name": "rate_limit_server__failing_tool",
         "tool_type": "downstream",
     }
-    "###);
+    "#);
 
     // Verify client_id is present
     let full_attrs: std::collections::BTreeMap<_, _> = error_metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }
 
 #[tokio::test]
@@ -1059,8 +1059,8 @@ async fn nexus_rate_limit_exceeded_metrics() {
         WHERE
             MetricName = 'mcp.tool.call.duration'
             AND ServiceName = '{service_name}'
-            AND Attributes['client_id'] = '{client_id}'
-            AND Attributes['error_type'] = 'rate_limit_exceeded'
+            AND Attributes['client.id'] = '{client_id}'
+            AND Attributes['error.type'] = 'rate_limit_exceeded'
         ORDER BY TimeUnix DESC
     "#};
 
@@ -1074,24 +1074,24 @@ async fn nexus_rate_limit_exceeded_metrics() {
     let attrs: std::collections::BTreeMap<_, _> = error_metrics[0]
         .attributes
         .iter()
-        .filter(|(k, _)| k.as_str() != "client_id")
+        .filter(|(k, _)| k.as_str() != "client.id")
         .cloned()
         .collect();
 
     // Verify the error is tracked as rate_limit_exceeded from Nexus itself
     // Note: server_name is not included when Nexus rate limits before reaching the server
-    insta::assert_debug_snapshot!(attrs, @r###"
+    insta::assert_debug_snapshot!(attrs, @r#"
     {
-        "error_type": "rate_limit_exceeded",
-        "group": "nexus-limit-group",
+        "client.group": "nexus-limit-group",
+        "error.type": "rate_limit_exceeded",
         "status": "error",
         "tool_name": "test_server__adder",
         "tool_type": "downstream",
     }
-    "###);
+    "#);
 
     // Verify client_id is present
     let full_attrs: std::collections::BTreeMap<_, _> = error_metrics[0].attributes.iter().cloned().collect();
     // Expected: client_id matches the one we sent in the request headers
-    assert_eq!(full_attrs.get("client_id"), Some(&client_id));
+    assert_eq!(full_attrs.get("client.id"), Some(&client_id));
 }

--- a/crates/integration-tests/tests/telemetry/metrics/redis.rs
+++ b/crates/integration-tests/tests/telemetry/metrics/redis.rs
@@ -1,0 +1,434 @@
+//! Redis metrics tests
+
+use clickhouse::Row;
+use indoc::formatdoc;
+use insta::assert_json_snapshot;
+use integration_tests::{
+    TestServer, TestService,
+    telemetry::{create_clickhouse_client, unique_service_name, wait_for_metrics_matching},
+    tools::AdderTool,
+};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+use crate::telemetry::metrics::HistogramMetricRow;
+
+// Custom row types for gauge queries that return calculated values
+#[derive(Row, Deserialize, Serialize, Debug, Clone)]
+#[serde(rename_all = "PascalCase")]
+struct GaugeMetricCheckRow {
+    metric_name: String,
+    attributes: Vec<(String, String)>,
+    is_non_negative: bool,
+}
+
+// Custom row type for token operation queries
+#[derive(Row, Deserialize, Serialize, Debug, Clone)]
+struct TokenOperationRow {
+    #[serde(rename = "MetricName")]
+    metric_name: String,
+    operation: String,
+    status: String,
+    has_tokens_attribute: bool,
+    #[serde(rename = "Count")]
+    count: u64,
+}
+
+// Helper function to create test config with Redis and telemetry enabled
+fn create_test_config_with_redis_metrics(service_name: &str, key_prefix: &str) -> String {
+    formatdoc! {r#"
+        [server]
+        listen_address = "127.0.0.1:0"
+
+        [server.rate_limits]
+        enabled = true
+
+        [server.rate_limits.storage]
+        type = "redis"
+        url = "redis://localhost:6379/0"
+        key_prefix = "{key_prefix}"
+
+        [server.rate_limits.global]
+        limit = 100
+        interval = "60s"
+
+        [telemetry]
+        service_name = "{service_name}"
+
+        [telemetry.resource_attributes]
+        environment = "test"
+
+        [telemetry.exporters.otlp]
+        enabled = true
+        endpoint = "http://localhost:4317"
+        protocol = "grpc"
+
+        [telemetry.exporters.otlp.batch_export]
+        scheduled_delay = "1s"
+        max_export_batch_size = 100
+
+        [mcp]
+        enabled = true
+        path = "/mcp"
+    "#}
+}
+
+#[tokio::test]
+async fn redis_command_duration_check_and_consume() {
+    let service_name = unique_service_name("redis-cmd-check-consume");
+    let key_prefix = format!("test_redis_cmd_{}:", uuid::Uuid::new_v4());
+    let config = create_test_config_with_redis_metrics(&service_name, &key_prefix);
+
+    let mut builder = TestServer::builder();
+    let mut service = TestService::streamable_http("test_server".to_string());
+    service.add_tool(AdderTool);
+    builder.spawn_service(service).await;
+
+    let test_server = builder.build(&config).await;
+
+    // Make requests that will trigger Redis rate limiting
+    for _ in 0..5 {
+        let response = test_server
+            .client
+            .post(
+                "/mcp",
+                &json!({
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 1
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+    }
+
+    // Wait for metrics to be exported
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let clickhouse = create_clickhouse_client().await;
+
+    // Query for specific check_and_consume operation metrics
+    // The Count field represents the actual number of observations
+    let query = formatdoc! {r#"
+        SELECT
+            MetricName,
+            Attributes,
+            Count
+        FROM otel_metrics_histogram
+        WHERE ResourceAttributes['service.name'] = '{service_name}'
+          AND MetricName = 'redis.command.duration'
+          AND Attributes['operation'] = 'check_and_consume'
+          AND Attributes['status'] = 'success'
+        ORDER BY TimeUnix DESC
+        LIMIT 1
+    "#};
+
+    let metrics = wait_for_metrics_matching::<HistogramMetricRow, _>(&clickhouse, &query, |rows| !rows.is_empty())
+        .await
+        .expect("Failed to get Redis check_and_consume metrics");
+
+    // The Count field represents the actual number of operations (5 requests made)
+    assert_json_snapshot!(metrics, @r#"
+    [
+      {
+        "MetricName": "redis.command.duration",
+        "Attributes": [
+          [
+            "operation",
+            "check_and_consume"
+          ],
+          [
+            "status",
+            "success"
+          ]
+        ],
+        "Count": 5
+      }
+    ]
+    "#);
+}
+
+#[tokio::test]
+async fn redis_pool_connections_in_use_gauge() {
+    let service_name = unique_service_name("redis-pool-in-use");
+    let key_prefix = format!("test_redis_pool_{}:", uuid::Uuid::new_v4());
+    let config = create_test_config_with_redis_metrics(&service_name, &key_prefix);
+
+    let mut builder = TestServer::builder();
+    let mut service = TestService::streamable_http("test_server".to_string());
+    service.add_tool(AdderTool);
+    builder.spawn_service(service).await;
+
+    let test_server = builder.build(&config).await;
+
+    // Make requests to exercise the connection pool
+    for _ in 0..3 {
+        let response = test_server
+            .client
+            .post(
+                "/mcp",
+                &json!({
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 1
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+    }
+
+    // Wait for metrics to be exported
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let clickhouse = create_clickhouse_client().await;
+
+    // Query for the latest in_use gauge metric
+    let query = formatdoc! {r#"
+        SELECT
+            MetricName,
+            Attributes,
+            Value >= 0 as is_non_negative
+        FROM otel_metrics_gauge
+        WHERE ResourceAttributes['service.name'] = '{service_name}'
+          AND MetricName = 'redis.pool.connections.in_use'
+        ORDER BY TimeUnix DESC
+        LIMIT 1
+    "#};
+
+    let metrics = wait_for_metrics_matching::<GaugeMetricCheckRow, _>(&clickhouse, &query, |rows| !rows.is_empty())
+        .await
+        .expect("Failed to get Redis pool in_use metric");
+
+    assert_json_snapshot!(metrics, @r#"
+    [
+      {
+        "MetricName": "redis.pool.connections.in_use",
+        "Attributes": [],
+        "IsNonNegative": true
+      }
+    ]
+    "#);
+}
+
+#[tokio::test]
+async fn redis_pool_connections_available_gauge() {
+    let service_name = unique_service_name("redis-pool-available");
+    let key_prefix = format!("test_redis_pool_{}:", uuid::Uuid::new_v4());
+    let config = create_test_config_with_redis_metrics(&service_name, &key_prefix);
+
+    let mut builder = TestServer::builder();
+    let mut service = TestService::streamable_http("test_server".to_string());
+    service.add_tool(AdderTool);
+    builder.spawn_service(service).await;
+
+    let test_server = builder.build(&config).await;
+
+    // Make requests to exercise the connection pool
+    for _ in 0..3 {
+        let response = test_server
+            .client
+            .post(
+                "/mcp",
+                &json!({
+                    "jsonrpc": "2.0",
+                    "method": "tools/list",
+                    "id": 1
+                }),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), 200);
+    }
+
+    // Wait for metrics to be exported
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let clickhouse = create_clickhouse_client().await;
+
+    // Query for the latest available gauge metric
+    let query = formatdoc! {r#"
+        SELECT
+            MetricName,
+            Attributes,
+            Value >= 0 as is_non_negative
+        FROM otel_metrics_gauge
+        WHERE ResourceAttributes['service.name'] = '{service_name}'
+          AND MetricName = 'redis.pool.connections.available'
+        ORDER BY TimeUnix DESC
+        LIMIT 1
+    "#};
+
+    let metrics = wait_for_metrics_matching::<GaugeMetricCheckRow, _>(&clickhouse, &query, |rows| !rows.is_empty())
+        .await
+        .expect("Failed to get Redis pool available metric");
+
+    assert_json_snapshot!(metrics, @r#"
+    [
+      {
+        "MetricName": "redis.pool.connections.available",
+        "Attributes": [],
+        "IsNonNegative": true
+      }
+    ]
+    "#);
+}
+
+#[tokio::test]
+async fn redis_metrics_with_errors() {
+    let service_name = unique_service_name("redis-error-metrics");
+    // Use an invalid Redis URL to trigger errors
+    let config = formatdoc! {r#"
+        [server]
+        listen_address = "127.0.0.1:0"
+
+        [server.rate_limits]
+        enabled = true
+
+        [server.rate_limits.storage]
+        type = "redis"
+        url = "redis://localhost:9999/0"  # Invalid port
+        key_prefix = "test_error:"
+        response_timeout = "100ms"
+
+        [server.rate_limits.global]
+        limit = 10
+        interval = "60s"
+
+        [telemetry]
+        service_name = "{service_name}"
+
+        [telemetry.exporters.otlp]
+        enabled = true
+        endpoint = "http://localhost:4317"
+        protocol = "grpc"
+
+        [telemetry.exporters.otlp.batch_export]
+        scheduled_delay = "1s"
+
+        [mcp]
+        enabled = true
+
+        [mcp.servers.dummy]
+        cmd = ["echo", "dummy"]
+    "#};
+
+    // This should fail to start due to Redis connection error
+    let result = std::panic::catch_unwind(|| {
+        tokio::runtime::Runtime::new()
+            .unwrap()
+            .block_on(async { TestServer::builder().build(&config).await })
+    });
+
+    // Simple boolean check - OK to use assert for primitives
+    assert!(result.is_err());
+}
+
+#[tokio::test]
+async fn redis_check_and_consume_tokens_operation() {
+    use integration_tests::llms::OpenAIMock;
+
+    let service_name = unique_service_name("redis-token-operation");
+    let key_prefix = format!("test_redis_token_{}:", uuid::Uuid::new_v4());
+
+    // Spawn the mock LLM server
+    let openai = OpenAIMock::new("test").with_models(vec!["gpt-4".to_string()]);
+    let mut builder = TestServer::builder();
+    builder.spawn_llm(openai).await;
+
+    let config = formatdoc! {r#"
+        [server]
+        listen_address = "127.0.0.1:0"
+
+        [server.client_identification]
+        enabled = true
+        client_id = {{ source = "http_header", http_header = "x-client-id" }}
+
+        [server.rate_limits]
+        enabled = true
+
+        [server.rate_limits.storage]
+        type = "redis"
+        url = "redis://localhost:6379/0"
+        key_prefix = "{key_prefix}"
+
+        [telemetry]
+        service_name = "{service_name}"
+
+        [telemetry.exporters.otlp]
+        enabled = true
+        endpoint = "http://localhost:4317"
+        protocol = "grpc"
+
+        [telemetry.exporters.otlp.batch_export]
+        scheduled_delay = "1s"
+
+        [llm.providers.test.models."gpt-4".rate_limits.per_user]
+        input_token_limit = 1000
+        interval = "60s"
+    "#};
+
+    let test_server = builder.build(&config).await;
+
+    // Make an LLM request that will trigger token rate limiting
+    // Use the raw client to properly send headers
+    let response = test_server
+        .client
+        .request(reqwest::Method::POST, "/llm/v1/chat/completions")
+        .json(&json!({
+            "model": "test/gpt-4",
+            "messages": [{"role": "user", "content": "Hello"}]
+        }))
+        .header("x-client-id", "test-user-1")
+        .send()
+        .await
+        .unwrap();
+
+    // Verify the request succeeded
+    assert_eq!(response.status(), 200);
+    let body = response.json::<serde_json::Value>().await.unwrap();
+    assert!(body["choices"].is_array());
+
+    // Wait for metrics to be exported
+    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+
+    let clickhouse = create_clickhouse_client().await;
+
+    // Query for token rate limit operations
+    // The Count field represents the actual number of operations
+    let query = formatdoc! {r#"
+        SELECT
+            MetricName,
+            Attributes['operation'] as operation,
+            Attributes['status'] as status,
+            mapContains(Attributes, 'tokens') as has_tokens_attribute,
+            Count
+        FROM otel_metrics_histogram
+        WHERE ResourceAttributes['service.name'] = '{service_name}'
+          AND MetricName = 'redis.command.duration'
+          AND Attributes['operation'] = 'check_and_consume_tokens'
+        ORDER BY TimeUnix DESC
+        LIMIT 1
+    "#};
+
+    let metrics = wait_for_metrics_matching::<TokenOperationRow, _>(&clickhouse, &query, |rows| !rows.is_empty())
+        .await
+        .expect("Failed to get Redis check_and_consume_tokens metrics");
+
+    // The Count field represents the actual number of operations (1 LLM request)
+    assert_json_snapshot!(metrics, @r###"
+    [
+      {
+        "MetricName": "redis.command.duration",
+        "operation": "check_and_consume_tokens",
+        "status": "success",
+        "has_tokens_attribute": true,
+        "Count": 1
+      }
+    ]
+    "###);
+}

--- a/crates/mcp/src/server/metrics.rs
+++ b/crates/mcp/src/server/metrics.rs
@@ -140,10 +140,10 @@ fn add_client_identity(recorder: &mut Recorder, context: &RequestContext<RoleSer
     if let Some(parts) = context.extensions.get::<Parts>()
         && let Some(identity) = parts.extensions.get::<config::ClientIdentity>()
     {
-        recorder.push_attribute("client_id", identity.client_id.clone());
+        recorder.push_attribute("client.id", identity.client_id.clone());
 
         if let Some(ref group) = identity.group {
-            recorder.push_attribute("group", group.clone());
+            recorder.push_attribute("client.group", group.clone());
         }
     }
 }
@@ -211,7 +211,7 @@ fn add_success_attributes(
 /// Add error-specific attributes
 fn add_error_attributes(recorder: &mut Recorder, tool_name: &str, actual_tool: Option<&str>, error: &ErrorData) {
     recorder.push_attribute("status", "error");
-    recorder.push_attribute("error_type", map_error_type(error.code));
+    recorder.push_attribute("error.type", map_error_type(error.code));
 
     match tool_name {
         "search" => {
@@ -318,7 +318,7 @@ fn map_result_attributes<T>(recorder: &mut Recorder, result: &Result<T, ErrorDat
         }
         Err(e) => {
             recorder.push_attribute("status", "error");
-            recorder.push_attribute("error_type", map_error_type(e.code));
+            recorder.push_attribute("error.type", map_error_type(e.code));
         }
     }
 }

--- a/crates/rate-limit/Cargo.toml
+++ b/crates/rate-limit/Cargo.toml
@@ -10,7 +10,9 @@ deadpool.workspace = true
 governor.workspace = true
 log.workspace = true
 mini-moka.workspace = true
+opentelemetry.workspace = true
 redis.workspace = true
+telemetry.workspace = true
 thiserror.workspace = true
 tokio.workspace = true
 

--- a/crates/rate-limit/src/storage/redis.rs
+++ b/crates/rate-limit/src/storage/redis.rs
@@ -163,7 +163,7 @@ impl RateLimitStorage for RedisStorage {
             }
             Err(e) => {
                 cmd_recorder.push_attribute("status", "error");
-                cmd_recorder.push_attribute("error_type", "script_execution");
+                cmd_recorder.push_attribute("error.type", "script_execution");
                 cmd_recorder.record();
                 return Err(StorageError::Query(format!("Rate limit script failed: {e}")));
             }
@@ -247,7 +247,7 @@ impl RateLimitStorage for RedisStorage {
             }
             Err(e) => {
                 cmd_recorder.push_attribute("status", "error");
-                cmd_recorder.push_attribute("error_type", "script_execution");
+                cmd_recorder.push_attribute("error.type", "script_execution");
                 cmd_recorder.record();
                 return Err(StorageError::Query(format!("Token rate limit script failed: {e}")));
             }

--- a/crates/telemetry/src/metrics/names.rs
+++ b/crates/telemetry/src/metrics/names.rs
@@ -41,3 +41,15 @@ pub const GEN_AI_CLIENT_TOTAL_TOKEN_USAGE: &str = "gen_ai.client.total.token.usa
 /// Time to first token in milliseconds (streaming only)
 /// Tracks the duration until the first token is received in a streaming response
 pub const GEN_AI_CLIENT_TIME_TO_FIRST_TOKEN: &str = "gen_ai.client.time_to_first_token";
+
+/// Redis command execution duration in milliseconds
+/// Tracks the duration of Redis operations (Lua scripts)
+pub const REDIS_COMMAND_DURATION: &str = "redis.command.duration";
+
+/// Redis connection pool connections in use
+/// Gauge tracking the number of connections currently checked out from the pool
+pub const REDIS_POOL_CONNECTIONS_IN_USE: &str = "redis.pool.connections.in_use";
+
+/// Redis connection pool connections available
+/// Gauge tracking the number of connections available in the pool
+pub const REDIS_POOL_CONNECTIONS_AVAILABLE: &str = "redis.pool.connections.available";


### PR DESCRIPTION
This PR adds OpenTelemetry metrics for Redis operations.

## Changes

### New Metrics

#### 1. **Redis Command Duration** (`redis.command.duration`)
- Type: Histogram (also functions as a counter via the Count field)
- Purpose: Tracks execution time of Redis operations
- Attributes:
  - `operation`: Type of Redis operation
    - `check_and_consume`: HTTP rate limit checking
    - `check_and_consume_tokens`: Token-based rate limit checking
  - `status`: `success` or `error`
  - `tokens`: Number of tokens (only for token operations)

#### 2. **Redis Pool Connections In Use** (`redis.pool.connections.in_use`)
- Type: Gauge
- Purpose: Monitors active connections from the pool
- Updated on-demand when pool is accessed

#### 3. **Redis Pool Connections Available** (`redis.pool.connections.available`)
- Type: Gauge
- Purpose: Monitors available connections in the pool
- Updated on-demand when pool is accessed
