### PR TITLE
fix(gb-9756): add nexus version back to the log

### DIFF
--- a/crates/integration-tests/src/lib.rs
+++ b/crates/integration-tests/src/lib.rs
@@ -749,6 +749,7 @@ impl TestServer {
             config: config.clone(),
             shutdown_signal: nexus_shutdown_signal_clone,
             log_filter: "server=debug,mcp=debug,telemetry=debug,rate_limit=debug,llm=debug,config=debug,integration_tests=debug,nexus=debug".to_string(),
+            version: "test".to_string(),
         };
 
         // Start the server in a background task

--- a/crates/integration-tests/tests/integration_tests.rs
+++ b/crates/integration-tests/tests/integration_tests.rs
@@ -182,6 +182,7 @@ async fn health_endpoint_separate_listener() {
         config,
         shutdown_signal: shutdown_signal.clone(),
         log_filter: "server=debug,mcp=debug,telemetry=debug,rate_limit=debug,llm=debug,config=debug,integration_tests=debug,nexus=debug".to_string(),
+        version: "test".to_string(),
     };
 
     drop(main_listener);

--- a/crates/server/src/lib.rs
+++ b/crates/server/src/lib.rs
@@ -43,6 +43,8 @@ pub struct ServeConfig {
     pub shutdown_signal: CancellationToken,
     /// Log filter string (e.g., "info" or "server=debug,mcp=debug")
     pub log_filter: String,
+    /// The version string to log on startup
+    pub version: String,
 }
 
 /// Starts and runs the Nexus server with the provided configuration.
@@ -52,9 +54,13 @@ pub async fn serve(
         config,
         shutdown_signal,
         log_filter,
+        version,
     }: ServeConfig,
 ) -> anyhow::Result<()> {
     let _telemetry_guard = init_otel(&config, log_filter).await;
+
+    // Log the version as the first message after logger initialization
+    log::info!("Nexus {version}");
     let mut app = Router::new();
 
     // Create CORS layer first, like Grafbase does

--- a/nexus/src/main.rs
+++ b/nexus/src/main.rs
@@ -15,8 +15,6 @@ async fn main() -> anyhow::Result<()> {
 
     // The server crate will handle telemetry and logger initialization
 
-    log::info!("Nexus {}", env!("CARGO_PKG_VERSION"));
-
     // Create a cancellation token for graceful shutdown
     let shutdown_signal = CancellationToken::new();
     let shutdown_signal_clone = shutdown_signal.clone();
@@ -75,5 +73,6 @@ fn serve_config(args: &Args, config: Config, shutdown_signal: CancellationToken)
         config,
         shutdown_signal,
         log_filter,
+        version: env!("CARGO_PKG_VERSION").to_string(),
     }
 }


### PR DESCRIPTION
The first log line when starting Nexus is now 'Nexus x.x.x', moved the version logging to immediately after logger initialization in the server crate.