### PR TITLE
chore(llm): Use common defaults for http client

### DIFF
--- a/crates/llm/src/provider.rs
+++ b/crates/llm/src/provider.rs
@@ -1,6 +1,7 @@
 pub(crate) mod anthropic;
 pub mod bedrock;
 pub(crate) mod google;
+mod http_client;
 mod model_manager;
 pub(crate) mod openai;
 mod token;

--- a/crates/llm/src/provider/anthropic.rs
+++ b/crates/llm/src/provider/anthropic.rs
@@ -20,7 +20,9 @@ use crate::{
         openai::Model,
         unified::{UnifiedRequest, UnifiedResponse},
     },
-    provider::{ChatCompletionStream, HttpProvider, ModelManager, Provider, token},
+    provider::{
+        ChatCompletionStream, HttpProvider, ModelManager, Provider, http_client::default_http_client_builder, token,
+    },
     request::RequestContext,
 };
 use config::HeaderRule;
@@ -56,14 +58,10 @@ impl AnthropicProvider {
             })?,
         );
 
-        let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(60))
-            .default_headers(headers)
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to create HTTP client for Anthropic provider: {e}");
-                LlmError::InternalError(None)
-            })?;
+        let client = default_http_client_builder(headers).build().map_err(|e| {
+            log::error!("Failed to create HTTP client for Anthropic provider: {e}");
+            LlmError::InternalError(None)
+        })?;
 
         let base_url = config
             .base_url

--- a/crates/llm/src/provider/google.rs
+++ b/crates/llm/src/provider/google.rs
@@ -20,7 +20,10 @@ use crate::{
         openai::Model,
         unified::{UnifiedChunk, UnifiedRequest, UnifiedResponse},
     },
-    provider::{HttpProvider, ModelManager, Provider, openai::extract_model_from_full_name, token},
+    provider::{
+        HttpProvider, ModelManager, Provider, http_client::default_http_client_builder,
+        openai::extract_model_from_full_name, token,
+    },
     request::RequestContext,
 };
 use config::HeaderRule;
@@ -37,13 +40,10 @@ pub(crate) struct GoogleProvider {
 
 impl GoogleProvider {
     pub fn new(name: String, config: ApiProviderConfig) -> crate::Result<Self> {
-        let client = Client::builder()
-            .timeout(std::time::Duration::from_secs(60))
-            .build()
-            .map_err(|e| {
-                log::error!("Failed to create HTTP client for Google provider: {e}");
-                LlmError::InternalError(None)
-            })?;
+        let client = default_http_client_builder(Default::default()).build().map_err(|e| {
+            log::error!("Failed to create HTTP client for Google provider: {e}");
+            LlmError::InternalError(None)
+        })?;
 
         let base_url = config
             .base_url

--- a/crates/llm/src/provider/http_client.rs
+++ b/crates/llm/src/provider/http_client.rs
@@ -1,0 +1,23 @@
+use std::time::Duration;
+
+use axum::http;
+use reqwest::Client;
+
+pub(super) fn default_http_client_builder(mut headers: http::HeaderMap) -> reqwest::ClientBuilder {
+    headers.insert(http::header::CONNECTION, http::HeaderValue::from_static("keep-alive"));
+
+    Client::builder()
+        .timeout(Duration::from_secs(60))
+        // Hyper connection pool only exposes two parameters max idle connections per host
+        // and idle connection timeout. There is not TTL on the connections themselves to
+        // force a refresh, necessary if the DNS changes its records. Somehow, even within
+        // a benchmark ramping *up* traffic, we do pick up DNS changes by setting a pool
+        // idle timeout of 5 seconds even though in theory no connection should be idle?
+        // A bit confusing, and I suspect I don't fully understand how Hyper is managing
+        // connections underneath. But seems like best choice we have right now, Grafbase
+        // Gateway/Apollo Router use this same default value.
+        .pool_idle_timeout(Some(Duration::from_secs(5)))
+        .tcp_nodelay(true)
+        .tcp_keepalive(Some(Duration::from_secs(60)))
+        .default_headers(headers)
+}


### PR DESCRIPTION
Using the same default reqwest options as the grafbase gateway.