### PR TITLE
chore(telemetry): Add ms unit to histogram

### DIFF
--- a/changelog/unreleased.md
+++ b/changelog/unreleased.md
@@ -1,0 +1,3 @@
+# Breaking Changes
+
+OpenTelemetry metrics are now reported in seconds with the `s` unit, instead of milliseconds.

--- a/crates/telemetry/src/metrics/recorder.rs
+++ b/crates/telemetry/src/metrics/recorder.rs
@@ -50,7 +50,7 @@ impl Recorder {
     pub fn new(name: &'static str) -> Self {
         Self {
             start: Instant::now(),
-            histogram: super::meter().f64_histogram(name).build(),
+            histogram: super::meter().f64_histogram(name).with_unit("s").build(),
             attributes: Vec::new(),
         }
     }
@@ -83,7 +83,7 @@ impl Recorder {
 
     /// Records the elapsed time to the histogram.
     pub fn record(self) {
-        let duration = self.start.elapsed().as_secs_f64() * 1000.0;
-        self.histogram.record(duration, &self.attributes);
+        self.histogram
+            .record(self.start.elapsed().as_secs_f64(), &self.attributes);
     }
 }


### PR DESCRIPTION
Ideally I think we should send the value in seconds, as OpenTelemetry spec specifies that time units should be in seconds. In Grafbase Gateway we did it in milli-seconds, but I would have used seconds now.

At least we should provide the proper unit.